### PR TITLE
Add 2FA

### DIFF
--- a/lib/helm/delete.rb
+++ b/lib/helm/delete.rb
@@ -1,0 +1,22 @@
+module Helm
+  class Delete
+    def self.call(release)
+      @release = release
+      remove_release if dry_run?
+    end
+
+    class <<self
+      private
+
+      def remove_release
+        result = `helm delete #{@release}`.chomp
+        result.eql?("release \"#{@release}\" uninstalled")
+      end
+
+      def dry_run?
+        result = `helm delete #{@release} --dry-run`.chomp
+        result.eql?("release \"#{@release}\" uninstalled")
+      end
+    end
+  end
+end

--- a/slack-applybot/bot.rb
+++ b/slack-applybot/bot.rb
@@ -43,13 +43,20 @@ module SlackApplybot
         name: 'helm',
         desc: '`@apply-bot helm <instruction>` e.g. `@apply-bot helm list`',
         long_desc: 'This will run a helm command against the UAT helm kubernetes cluster ' \
-                   'currently supported instructions are: `list`, `tidy`'
+                   'currently supported instructions are: `list`, `tidy` & `delete` ' \
+                   'delete will need to be followed by a 2fa code, see `help 2fa`'
       },
       {
         name: 'github',
         desc: '`@apply-bot github <instruction>` e.g. `@apply-bot github link <your github name>`',
         long_desc: 'This will run a command that links your current slack account ' \
-                   'with a github account, currently supported instruction is: `link`'
+                     'with a github account, currently supported instruction is: `link`'
+      },
+      {
+        name: '2fa',
+        desc: '`@apply-bot 2fa <instruction>` e.g. `@apply-bot 2fa setup`',
+        long_desc: 'This will enable two-factor authentication for you to issue potentially ' \
+                   'destructive commands, currently supported instructions are: `setup`, `confirm`'
       }
     ].freeze
 

--- a/slack-applybot/commands/_channel_validity.rb
+++ b/slack-applybot/commands/_channel_validity.rb
@@ -23,10 +23,10 @@ module ChannelValidity
     ENV['ALLOWED_CHANNEL_LIST'].include?(channel_name)
   end
 
-  # def channel_is_not_dm?
-  #   @channel_info = SendSlackMessage.new.conversations_info(channel: @data.channel)
-  #   @channel_info['channel']['is_im']&.eql?(false)
-  # end
+  def channel_is_not_dm?
+    @channel_info = SendSlackMessage.new.conversations_info(channel: @data.channel)
+    @channel_info['channel']['is_im']&.eql?(false)
+  end
 
   def error_message
     ERROR_MESSAGE.sub('|USERNAME|', @data.user)

--- a/slack-applybot/commands/_two_factor_auth.rb
+++ b/slack-applybot/commands/_two_factor_auth.rb
@@ -1,0 +1,10 @@
+module TwoFactorAuth
+  require 'rotp'
+
+  private
+
+  def validate(user, otp)
+    totp = ROTP::TOTP.new(Encryption::Service.decrypt(user.encrypted_2fa_secret), issuer: ENV.fetch('SERVICE_NAME'))
+    totp.verify(otp)
+  end
+end

--- a/slack-applybot/commands/_two_factor_auth_shared.rb
+++ b/slack-applybot/commands/_two_factor_auth_shared.rb
@@ -1,7 +1,11 @@
-module TwoFactorAuth
+module TwoFactorAuthShared
   require 'rotp'
 
   private
+
+  def validate_otp_part(otp)
+    validate(user, otp) if otp.match(/\d*/)
+  end
 
   def validate(user, otp)
     totp = ROTP::TOTP.new(Encryption::Service.decrypt(user.encrypted_2fa_secret), issuer: ENV.fetch('SERVICE_NAME'))

--- a/slack-applybot/commands/_user_command.rb
+++ b/slack-applybot/commands/_user_command.rb
@@ -6,4 +6,8 @@ module UserCommand
   def user_dm_channel(client)
     client.web_client.conversations_open(users: user)['channel']['id']
   end
+
+  def user_has_github_linked?
+    user.github_id.present?
+  end
 end

--- a/slack-applybot/commands/_user_command.rb
+++ b/slack-applybot/commands/_user_command.rb
@@ -2,4 +2,8 @@ module UserCommand
   def user
     User.find_or_create_by(slack_id: @data.user)
   end
+
+  def user_dm_channel(client)
+    client.web_client.conversations_open(users: user)['channel']['id']
+  end
 end

--- a/slack-applybot/commands/_user_command.rb
+++ b/slack-applybot/commands/_user_command.rb
@@ -4,7 +4,7 @@ module UserCommand
   end
 
   def user_dm_channel(client)
-    client.web_client.conversations_open(users: user)['channel']['id']
+    client.web_client.conversations_open(users: user.slack_id)['channel']['id']
   end
 
   def user_has_github_linked?

--- a/slack-applybot/commands/helm.rb
+++ b/slack-applybot/commands/helm.rb
@@ -1,6 +1,7 @@
 module SlackApplybot
   module Commands
     class Helm < SlackRubyBot::Commands::Base
+      require 'pry-byebug'
       command 'helm' do |client, data, match|
         @client = client
         @data = data
@@ -10,6 +11,8 @@ module SlackApplybot
         message = case match['expression']
                   when 'list', 'tidy'
                     "::Helm::#{match['expression'].capitalize}".constantize.call
+                  when /^delete/
+                    process_delete(match)
                   when nil
                     SlackRubyBot::Commands::Support::Help.instance.command_full_desc('helm')
                   else
@@ -21,7 +24,25 @@ module SlackApplybot
 
       class << self
         include ChannelValidity
+        include TwoFactorAuth
         include UserCommand
+
+        def process_delete(match)
+          parts = match['expression'].split - ['delete']
+          if parts.empty?
+            'Unable to delete - insufficient data, please call as `helm delete name-of-release 000000`'
+          elsif parts.count.eql?(1)
+            'OTP password not provided, please call as `helm delete name-of-release 000000`'
+          elsif validate_otp_part(parts[1])
+            ::Helm::Delete.call(parts[0]) ? "#{parts[0]} deleted" : 'Unable to delete'
+          else
+            'OTP password did not match, please check your authenticator app'
+          end
+        end
+
+        def validate_otp_part(otp)
+          validate(user, otp) if otp.match(/\d*/)
+        end
       end
     end
   end

--- a/slack-applybot/commands/helm.rb
+++ b/slack-applybot/commands/helm.rb
@@ -24,7 +24,7 @@ module SlackApplybot
 
       class << self
         include ChannelValidity
-        include TwoFactorAuth
+        include TwoFactorAuthShared
         include UserCommand
 
         def process_delete(match)
@@ -38,10 +38,6 @@ module SlackApplybot
           else
             'OTP password did not match, please check your authenticator app'
           end
-        end
-
-        def validate_otp_part(otp)
-          validate(user, otp) if otp.match(/\d*/)
         end
       end
     end

--- a/slack-applybot/commands/two_factor_auth.rb
+++ b/slack-applybot/commands/two_factor_auth.rb
@@ -13,21 +13,15 @@ module SlackApplybot
         client.typing(channel: data.channel)
         case match['expression']&.downcase
         when 'setup'
-          channel = data.channel
-          if channel_is_not_dm?
-            message_text = "I've sent you a DM, we probably shouldn't be talking about this in public!"
-            client.say(channel: channel, text: message_text)
-            channel = client.web_client.conversations_open(users: data['user'])['channel']['id']
-          end
-
-          send_qr_message(channel)
+          send_qr_message(user_dm_channel(client))
+          message = "I've sent you a DM, we probably shouldn't be talking about this in public!" if channel_is_not_dm?
         when /^confirm/
-          message = process_confirmation(match)
-          client.say(channel: data.channel, text: message)
+          client.say(channel: user_dm_channel(client), text: process_confirmation(match))
+          message = "I've sent you a DM, we probably shouldn't be talking about this in public!" if channel_is_not_dm?
         else
           message = "You called `2fa` with `#{match['expression']}`. This is not supported."
-          client.say(channel: data.channel, text: message)
         end
+        client.say(channel: data.channel, text: message) if message
       end
 
       class << self

--- a/slack-applybot/commands/two_factor_auth.rb
+++ b/slack-applybot/commands/two_factor_auth.rb
@@ -13,7 +13,12 @@ module SlackApplybot
         client.typing(channel: data.channel)
         case match['expression']&.downcase
         when 'setup'
-          send_qr_message(user_dm_channel(client))
+          user_dm = user_dm_channel(client)
+          if user_has_github_linked?
+            send_qr_message(user_dm)
+          else
+            send_dm_to_link_github(user_dm)
+          end
           message = "I've sent you a DM, we probably shouldn't be talking about this in public!" if channel_is_not_dm?
         when /^confirm/
           client.say(channel: user_dm_channel(client), text: process_confirmation(match))
@@ -38,6 +43,11 @@ module SlackApplybot
           else
             'OTP password did not match, please check your authenticator app'
           end
+        end
+
+        def send_dm_to_link_github(channel)
+          message = 'You need to link your github account before you can setup 2FA'
+          @client.say(channel: channel, text: message)
         end
 
         def send_qr_message(channel)

--- a/slack-applybot/commands/two_factor_auth.rb
+++ b/slack-applybot/commands/two_factor_auth.rb
@@ -1,0 +1,54 @@
+module SlackApplybot
+  module Commands
+    class TwoFactorAuth < SlackRubyBot::Commands::Base
+      require 'rotp'
+      require 'rqrcode'
+
+      command '2fa setup' do |client, data, _match|
+        @client = client
+        @data = data
+        raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
+
+        client.typing(channel: data.channel)
+        channel = data.channel
+        if channel_is_not_dm?
+          message_text = "I've sent you a DM, we probably shouldn't be talking about this in public!"
+          client.say(channel: channel, text: message_text)
+          channel = client.web_client.conversations_open(users: data['user'])['channel']['id']
+        end
+
+        send_qr_message(channel)
+      end
+
+      class << self
+        include ChannelValidity
+        include UserCommand
+
+        def send_qr_message(channel)
+          user.otp_secret = ROTP::Base32.random if user.encrypted_2fa_secret.nil?
+          token = Encryption::Service.decrypt(user.encrypted_2fa_secret)
+          SendSlackMessage.new.upload_file(
+            channels: channel,
+            as_user: true,
+            file: Faraday::FilePart.new(StringIO.new(build_qr_code(token)), 'image/png'),
+            title: 'Your apply-bot QR',
+            initial_comment: 'Scan with an authenticator app'
+          )
+        end
+
+        def build_qr_code(token)
+          totp = ROTP::TOTP.new(token, issuer: ENV.fetch('SERVICE_NAME'))
+          qrcode = RQRCode::QRCode.new(totp.provisioning_uri(ENV.fetch('SERVICE_EMAIL')))
+
+          qrcode.as_svg(
+            size: 1,
+            offset: 10,
+            shape_rendering: 'crispEdges',
+            module_size: 6,
+            standalone: true
+          )
+        end
+      end
+    end
+  end
+end

--- a/slack-applybot/commands/two_factor_auth.rb
+++ b/slack-applybot/commands/two_factor_auth.rb
@@ -56,7 +56,7 @@ module SlackApplybot
           SendSlackMessage.new.upload_file(
             channels: channel,
             as_user: true,
-            file: Faraday::FilePart.new(StringIO.new(build_qr_code(token)), 'image/png'),
+            file: Faraday::FilePart.new(StringIO.new(build_qr_code(token)), 'image/png', 'apply_bot_qr.png'),
             title: 'Your apply-bot QR',
             initial_comment: 'Scan with an authenticator app'
           )
@@ -66,13 +66,11 @@ module SlackApplybot
           totp = ROTP::TOTP.new(token, issuer: ENV.fetch('SERVICE_NAME'))
           qrcode = RQRCode::QRCode.new(totp.provisioning_uri(ENV.fetch('SERVICE_EMAIL')))
 
-          qrcode.as_svg(
-            size: 1,
-            offset: 10,
-            shape_rendering: 'crispEdges',
-            module_size: 6,
-            standalone: true
-          )
+          qrcode.as_png(
+            border_modules: 1,
+            resize_exactly_to: true,
+            size: 180
+          ).to_s
         end
       end
     end

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -27,7 +27,8 @@ describe SlackRubyBot::Commands::Help, :vcr do
     "\n*uat urls* - `@apply-bot uat urls`"\
     "\n*uat url* - `@apply-bot uat url <branch> e.g. @apply-bot uat url ap-999`"\
     "\n*helm* - `@apply-bot helm <instruction>` e.g. `@apply-bot helm list`"\
-    "\n*github* - `@apply-bot github <instruction>` e.g. `@apply-bot github link <your github name>`\n"\
+    "\n*github* - `@apply-bot github <instruction>` e.g. `@apply-bot github link <your github name>`"\
+    "\n*2fa* - `@apply-bot 2fa <instruction>` e.g. `@apply-bot 2fa setup`\n"\
     "\nFor full description of the command use: *help <command>*\n"
   end
   # TODO: find out why the ruby-slack-bot is inserting thw weather bot output into the test response!

--- a/spec/commands/two_factor_auth_spec.rb
+++ b/spec/commands/two_factor_auth_spec.rb
@@ -25,12 +25,19 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
   let(:channel) { 'channel' }
   let(:is_direct_message?) { false }
   let(:command) { 'setup' }
+  let(:user_input) { "#{SlackRubyBot.config.user} 2fa #{command}" }
+  let(:expected_hash) do
+    {
+      channel: channel,
+      text: expected_message
+    }
+  end
+  let!(:client) { SlackRubyBot::App.new.send(:client) }
+  let(:message_hook) { SlackRubyBot::Hooks::Message.new }
+  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
 
   describe '#setup' do
-    let(:user_input) { "#{SlackRubyBot.config.user} 2fa #{command}" }
-    let!(:client) { SlackRubyBot::App.new.send(:client) }
-    let(:message_hook) { SlackRubyBot::Hooks::Message.new }
-    let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
+    let(:command) { 'setup' }
 
     context 'the user is in a direct message channel' do
       let(:is_direct_message?) { true }
@@ -42,22 +49,56 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
 
     context 'the user is in a public, valid channel' do
       let(:expected_message) { "I've sent you a DM, we probably shouldn't be talking about this in public!" }
-      let(:expected_hash) do
-        {
-          channel: channel,
-          text: expected_message
-        }
-      end
 
       it 'responds with a warning message' do
         expect(client).to receive(:typing)
         expect(client).to receive(:say).with(expected_hash)
         message_hook.call(client, params)
       end
+    end
+  end
 
-      context 'when the command is unsupported' do
-        let(:command) { 'cancel' }
-        let(:expected_message) { 'You called `2fa` with `cancel`. This is not supported.' }
+  describe '#confirm' do
+    let(:user_input) { "#{SlackRubyBot.config.user} 2fa #{command} #{otp_code}" }
+    let(:command) { 'confirm' }
+
+    context 'but no OTP is provided' do
+      let(:otp_code) { '' }
+      let(:expected_message) do
+        'OTP password not provided, please call as `2fa confirm 000000`'
+      end
+
+      it 'returns the expected message' do
+        expect(client).to receive(:typing)
+        expect(client).to receive(:say).with(expected_hash)
+        message_hook.call(client, params)
+      end
+    end
+
+    context 'when OTP is provided' do
+      before do
+        allow_any_instance_of(User).to receive(:encrypted_2fa_secret).and_return(encrypted_secret)
+        allow_any_instance_of(Encryption::Service).to receive(:decrypt).with(:any).and_return('123456789')
+        allow_any_instance_of(ROTP::TOTP).to receive(:verify).with('123456').and_return(valid_token?)
+      end
+      let(:encrypted_secret) { Encryption::Service.encrypt('secret') }
+      let(:otp_code) { '123456' }
+
+      context 'and it is correct' do
+        let(:expected_message) { 'OTP has been successfully configured' }
+        let(:valid_token?) { true }
+
+        it 'returns the expected message' do
+          expect(client).to receive(:typing)
+          expect(client).to receive(:say).with(expected_hash)
+          message_hook.call(client, params)
+        end
+      end
+
+      context 'but it is incorrect' do
+        let(:expected_message) { 'OTP password did not match, please check your authenticator app' }
+        let(:valid_token?) { false }
+
         it 'returns the expected message' do
           expect(client).to receive(:typing)
           expect(client).to receive(:say).with(expected_hash)
@@ -65,7 +106,17 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
         end
       end
     end
-
-    it_behaves_like 'the channel is invalid'
   end
+
+  context 'when the command is unsupported' do
+    let(:command) { 'cancel' }
+    let(:expected_message) { 'You called `2fa` with `cancel`. This is not supported.' }
+    it 'returns the expected message' do
+      expect(client).to receive(:typing)
+      expect(client).to receive(:say).with(expected_hash)
+      message_hook.call(client, params)
+    end
+  end
+
+  it_behaves_like 'the channel is invalid'
 end

--- a/spec/commands/two_factor_auth_spec.rb
+++ b/spec/commands/two_factor_auth_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
   end
   let(:channel) { 'channel' }
   let(:is_direct_message?) { false }
+  let(:command) { 'setup' }
 
   describe '#setup' do
-    let(:user_input) { "#{SlackRubyBot.config.user} 2fa setup" }
+    let(:user_input) { "#{SlackRubyBot.config.user} 2fa #{command}" }
     let!(:client) { SlackRubyBot::App.new.send(:client) }
     let(:message_hook) { SlackRubyBot::Hooks::Message.new }
     let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
@@ -40,10 +41,11 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
     end
 
     context 'the user is in a public, valid channel' do
+      let(:expected_message) { "I've sent you a DM, we probably shouldn't be talking about this in public!" }
       let(:expected_hash) do
         {
           channel: channel,
-          text: "I've sent you a DM, we probably shouldn't be talking about this in public!"
+          text: expected_message
         }
       end
 
@@ -51,6 +53,16 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
         expect(client).to receive(:typing)
         expect(client).to receive(:say).with(expected_hash)
         message_hook.call(client, params)
+      end
+
+      context 'when the command is unsupported' do
+        let(:command) { 'cancel' }
+        let(:expected_message) { 'You called `2fa` with `cancel`. This is not supported.' }
+        it 'returns the expected message' do
+          expect(client).to receive(:typing)
+          expect(client).to receive(:say).with(expected_hash)
+          message_hook.call(client, params)
+        end
       end
     end
 

--- a/spec/commands/two_factor_auth_spec.rb
+++ b/spec/commands/two_factor_auth_spec.rb
@@ -1,0 +1,59 @@
+require 'rspec'
+
+RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
+  before do
+    stub_request(:post, %r{\Ahttps://slack.com/api/conversations.info\z}).to_return(status: 200, body: expected_body)
+    stub_request(:post, %r{\Ahttps://slack.com/api/conversations.open\z}).to_return(status: 200, body: user_body)
+  end
+  let(:expected_body) do
+    {
+      'ok': true,
+      'channel': {
+        name: channel,
+        is_im: is_direct_message?
+      }
+    }.to_json
+  end
+  let(:user_body) do
+    {
+      'ok': true,
+      'channel': {
+        id: 'A0000B1CDEF'
+      }
+    }.to_json
+  end
+  let(:channel) { 'channel' }
+  let(:is_direct_message?) { false }
+
+  describe '#setup' do
+    let(:user_input) { "#{SlackRubyBot.config.user} 2fa setup" }
+    let!(:client) { SlackRubyBot::App.new.send(:client) }
+    let(:message_hook) { SlackRubyBot::Hooks::Message.new }
+    let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
+
+    context 'the user is in a direct message channel' do
+      let(:is_direct_message?) { true }
+
+      it 'starts typing' do
+        expect(message: user_input, channel: 'channel').to start_typing(channel: 'channel')
+      end
+    end
+
+    context 'the user is in a public, valid channel' do
+      let(:expected_hash) do
+        {
+          channel: channel,
+          text: "I've sent you a DM, we probably shouldn't be talking about this in public!"
+        }
+      end
+
+      it 'responds with a warning message' do
+        expect(client).to receive(:typing)
+        expect(client).to receive(:say).with(expected_hash)
+        message_hook.call(client, params)
+      end
+    end
+
+    it_behaves_like 'the channel is invalid'
+  end
+end

--- a/spec/lib/helm/delete_spec.rb
+++ b/spec/lib/helm/delete_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Helm::Delete do
+  describe '#call' do
+    subject(:call) { described_class.call('ap1234') }
+    before { allow(described_class).to receive(:`).with(/helm delete.*/).and_return(response) }
+    let(:response) { 'release "ap1234" uninstalled' }
+
+    it { expect(subject).to eql(true) }
+  end
+end


### PR DESCRIPTION
Add methods for linking a github account to yourself on slack.

If your github account is part of the @laa-apply-for-legal-aid github group, you will be allowed to 
setup two-factor authentication

2FA will allow you to run the new, destructive, `helm delete` command