### PR TITLE
Turn off bot messaging

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,7 +28,7 @@ class App < Sinatra::Base
   ActiveRecord::Base.logger.level = Logger::WARN if ActiveRecord::Base.logger
   SlackRubyBot::Client.logger.level = Logger::WARN
   SlackRubyBot.configure do |config|
-    config.allow_bot_messages = true
+    config.allow_bot_messages = false
   end
   get '/' do
     "


### PR DESCRIPTION
Prevent errors when slack bot tries to expand
links, they weren't needed anyway