### PR TITLE
Extend helm list

### DIFF
--- a/lib/helm/github_bits.rb
+++ b/lib/helm/github_bits.rb
@@ -1,0 +1,39 @@
+module GithubBits
+  PREFIX = 'apply-'.freeze
+
+  private
+
+  def open_branches
+    application = ApplyApplication.new
+    Github::Branches.call(application)
+  end
+
+  def branch_data
+    @branch_data ||= JSON.parse(open_branches.to_json, symbolize_names: true).map do |branch|
+      branch[:name]
+    end
+  end
+
+  def branch_still_exists(environment)
+    branch_data.map { |pr_title| pr_title.include?(environment.delete_prefix(PREFIX)) }.any?
+  end
+
+  def open_pull_requests
+    application = ApplyApplication.new
+    Github::PullRequests.call(application)
+  end
+
+  def pull_request_data
+    @pull_request_data ||= JSON.parse(open_pull_requests.to_json, symbolize_names: true).map do |pr|
+      pr[:head][:ref].gsub(%r{[()\[\]_/\s.]}, '-')
+    end
+  end
+
+  def pr_still_exists(environment)
+    pull_request_data.map { |pr_title| pr_title.include?(environment.delete_prefix(PREFIX)) }.any?
+  end
+
+  def still_exists?(environment)
+    branch_still_exists(environment) || pr_still_exists(environment)
+  end
+end

--- a/lib/helm/list.rb
+++ b/lib/helm/list.rb
@@ -3,7 +3,8 @@ module Helm
     def self.call
       releases = JSON.parse(`helm list -o json`, symbolize_names: true)
       values = releases.pluck(:name, :status, :updated)
-      "#{header}\n#{values.map { |row| parse_row(row) }.join("\n")}"
+      result = "#{header}\n#{values.map { |row| parse_row(row) }.join("\n")}"
+      "```#{result}```"
     end
 
     class <<self

--- a/lib/helm/list.rb
+++ b/lib/helm/list.rb
@@ -8,14 +8,30 @@ module Helm
     end
 
     class <<self
+      include GithubBits
+
       private
 
       def header
-        "#{parse_name('Name')}#{parse_state('Status')}Date"
+        # "#{parse_name('Name')}#{parse_state('Status')}#{'Date'.ljust(11)}#{parse_data('Branch')}#{parse_data('PR')}"
+        [
+          parse_name('Name'),
+          parse_state('Status'),
+          'Date'.ljust(11),
+          'PR'.ljust(3, ' '),
+          parse_data('Branch')
+        ].join
       end
 
       def parse_row(data)
-        "#{parse_name(data[0])}#{parse_state(data[1])}#{parse_date(data[2]).strftime('%Y-%m-%d')}"
+        # "#{parse_name(data[0])}#{parse_state(data[1])}#{parse_date(data[2]).strftime('%Y-%m-%d')}"
+        [
+          parse_name(data[0]),
+          parse_state(data[1]),
+          parse_date(data[2]).strftime('%Y-%m-%d').ljust(11),
+          (pr_still_exists(data[0]) ? '✔' : '').ljust(3, ' '),
+          parse_data((branch_still_exists(data[0]) ? '✔' : ''))
+        ].join
       end
 
       def parse_name(name)
@@ -24,6 +40,10 @@ module Helm
 
       def parse_state(state)
         state.ljust(15, ' ')
+      end
+
+      def parse_data(value)
+        value.ljust(7, ' ')
       end
 
       def parse_date(date)

--- a/lib/helm/tidy.rb
+++ b/lib/helm/tidy.rb
@@ -1,7 +1,5 @@
 module Helm
   class Tidy
-    PREFIX = 'apply-'.freeze
-
     def self.call
       @output = ''
       @count = 0
@@ -13,45 +11,13 @@ module Helm
     end
 
     class << self
+      include GithubBits
+
       private
 
       def active_uat_namespaces
         uat_releases = JSON.parse(`helm list -o json`, symbolize_names: true)
         uat_releases.map { |helm| helm[:name] } - ["#{PREFIX}master"]
-      end
-
-      def open_branches
-        application = ApplyApplication.new
-        Github::Branches.call(application)
-      end
-
-      def branch_data
-        @branch_data ||= JSON.parse(open_branches.to_json, symbolize_names: true).map do |branch|
-          branch[:name]
-        end
-      end
-
-      def branch_still_exists(environment)
-        branch_data.map { |pr_title| pr_title.include?(environment.delete_prefix(PREFIX)) }.any?
-      end
-
-      def open_pull_requests
-        application = ApplyApplication.new
-        Github::PullRequests.call(application)
-      end
-
-      def pull_request_data
-        @pull_request_data ||= JSON.parse(open_pull_requests.to_json, symbolize_names: true).map do |pr|
-          pr[:head][:ref].gsub(%r{[()\[\]_/\s.]}, '-')
-        end
-      end
-
-      def pr_still_exists(environment)
-        pull_request_data.map { |pr_title| pr_title.include?(environment.delete_prefix(PREFIX)) }.any?
-      end
-
-      def still_exists?(environment)
-        branch_still_exists(environment) || pr_still_exists(environment)
       end
 
       def update_output_for(environment)

--- a/slack-applybot/commands/helm.rb
+++ b/slack-applybot/commands/helm.rb
@@ -8,10 +8,7 @@ module SlackApplybot
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
         message = case match['expression']
-                  when 'list'
-                    result = "::Helm::#{match['expression'].capitalize}".constantize.call
-                    "```#{result}```"
-                  when 'tidy'
+                  when 'list', 'tidy'
                     "::Helm::#{match['expression'].capitalize}".constantize.call
                   when nil
                     SlackRubyBot::Commands::Support::Help.instance.command_full_desc('helm')

--- a/spec/commands/helm_spec.rb
+++ b/spec/commands/helm_spec.rb
@@ -43,7 +43,7 @@ describe SlackApplybot::Commands::Helm, :vcr do
 
     context 'when the command is list' do
       let(:command) { 'list' }
-      let(:command_response) { "```ap1234\nap2345```" }
+      let(:command_response) { "ap1234\nap2345" }
       it 'returns the expected message' do
         expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
       end

--- a/spec/lib/helm/list_spec.rb
+++ b/spec/lib/helm/list_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe Helm::List do
       ].to_json
     end
     let(:expected) do
-      "Name                                    Status         Date\n"\
+      '```'\
+      "Name                                    Status         Date       Branch PR     \n"\
       "apply-ap-1234-first-name                deployed       2021-02-10\n"\
-      'apply-ap-2345-second-name               deployed       2021-02-10'
+      'apply-ap-2345-second-name               deployed       2021-02-10'\
+      '```'
     end
 
     it { expect(subject).to eql(expected) }

--- a/spec/lib/helm/list_spec.rb
+++ b/spec/lib/helm/list_spec.rb
@@ -3,7 +3,28 @@ require 'spec_helper'
 RSpec.describe Helm::List do
   describe '#call' do
     subject(:call) { described_class.call }
-    before { allow(described_class).to receive(:`).with('helm list -o json').and_return(raw_json) }
+    let(:github_url) { 'https://api.github.com/repos/moj/project-app' }
+    before do
+      allow(described_class).to receive(:`).with('helm list -o json').and_return(raw_json)
+      stub_request(:get, "#{github_url}/branches?per_page=100").to_return(status: 200,
+                                                                          body: truncated_branch_data.to_json,
+                                                                          headers: {})
+      stub_request(:get, "#{github_url}/pulls").to_return(status: 200,
+                                                          body: truncated_pr_data.to_json,
+                                                          headers: {})
+    end
+    let(:truncated_branch_data) do
+      [
+        { 'name' => 'ap-1234-first-name' },
+        { 'name' => 'ap-5432-second-name' }
+      ]
+    end
+    let(:truncated_pr_data) do
+      [
+        { 'head' => { 'ref' => 'ap-1234-first-name' } },
+        { 'head' => { 'ref' => 'ap-5432-second-name' } }
+      ]
+    end
     let(:raw_json) do
       [
         {
@@ -28,9 +49,9 @@ RSpec.describe Helm::List do
     end
     let(:expected) do
       '```'\
-      "Name                                    Status         Date       Branch PR     \n"\
-      "apply-ap-1234-first-name                deployed       2021-02-10\n"\
-      'apply-ap-2345-second-name               deployed       2021-02-10'\
+      "Name                                    Status         Date       PR Branch \n"\
+      "apply-ap-1234-first-name                deployed       2021-02-10 ✔  ✔      \n"\
+      'apply-ap-2345-second-name               deployed       2021-02-10           '\
       '```'
     end
 


### PR DESCRIPTION
Add columns to display reasons for keeping, 
i.e. does a branch or pull request still exist
This can probably be deleted ultimately, but
will be useful for debugging unexpected
`helm tidy` outputs