### PR TITLE
Fix: Add ineteractive endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -43,4 +43,10 @@ class App < Sinatra::Base
       build_tag: ENV['BUILD_TAG'] || 'Not Available'
     }.to_json
   end
+
+  post '/interactive' do
+    # return empty success response to prevent
+    # warnings in slack when buttons are clicked
+    [200, {}, ['']]
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -49,4 +49,10 @@ describe 'Sinatra App' do
       expect(last_response.status).to eq 200
     end
   end
+
+  it 'swallows any data posted to interactive' do
+    post '/interactive', { data: 'something' }
+    expect(last_response.body).to eql ''
+    expect(last_response.status).to eq 200
+  end
 end


### PR DESCRIPTION
Because the HMRC interface circle now uses the bot, when
clicking on a button to merge a branch it displays a
warning that there is no interactive handling in the bot

This allows us to link it in the slack API but swallow any
data sent and prevent leaking data by using a third party
API test endpoint