### PR TITLE
Post eks migration tidy

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Build and push production - live
         env:
           K8S_TOKEN: ${{ secrets.K8S_LIVE_TOKEN }}

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -21,7 +21,6 @@ jobs:
           K8S_TOKEN: ${{ secrets.K8S_LIVE_TOKEN }}
           K8S_CLUSTER_CERT: ${{ secrets.K8S_LIVE_CLUSTER_CERT }}
           K8S_CLUSTER_NAME: ${{ secrets.K8S_LIVE_CLUSTER_NAME }}
-          K8S_CLUSTER_PREFIX: ''
           K8S_NAMESPACE: ${{ secrets.K8S_NAMESPACE }}
           SERVICE_ACCOUNT: ${{ secrets.LIVE_SERVICE_ACCOUNT }}
           ECR_USERNAME: ${{ secrets.ECR_USERNAME }}

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -14,6 +14,9 @@ out=$(docker push ${TAG})
 echo $out
 
 echo "Applying namespace configuration to ${K8S_NAMESPACE}..."
+kubectl -n ${K8S_NAMESPACE} apply -f kubectl_deploy/website-service.yaml
+kubectl -n ${K8S_NAMESPACE} apply -f kubectl_deploy/website-ingress.yaml
+kubectl -n ${K8S_NAMESPACE} apply -f kubectl_deploy/secrets.yaml
 kubectl -n ${K8S_NAMESPACE} set image -f kubectl_deploy/website-deployment.yaml website=${TAG} --local -o yaml | kubectl -n ${K8S_NAMESPACE} apply -f -
 kubectl -n ${K8S_NAMESPACE} set image -f kubectl_deploy/sidekiq-deployment.yaml sidekiq=${TAG} --local -o yaml | kubectl -n ${K8S_NAMESPACE} apply -f -
 kubectl -n ${K8S_NAMESPACE} rollout status deployments/website

--- a/scripts/environment_setup.sh
+++ b/scripts/environment_setup.sh
@@ -16,7 +16,7 @@ sudo curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-relea
 sudo chmod +x /usr/bin/kubectl
 
 echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
-kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_PREFIX}${K8S_CLUSTER_NAME}
+kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME}
 kubectl config set-credentials ${SERVICE_ACCOUNT} --token=${K8S_TOKEN}
 kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=${SERVICE_ACCOUNT} --namespace=${K8S_NAMESPACE}
 kubectl config use-context ${K8S_CLUSTER_NAME}


### PR DESCRIPTION
Remove K8S_CLUSTER_PREFIX - this was needed when one cluster needed to be prefixed `api.`
Change the branch name from master to main, this default branch has never been named master 😕 
Update build_and_push - Run all the relevant deploy jobs, rather than expect them to have been run by an individual user