### PR TITLE
Tech-debt: lock activerecord at 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 ruby '3.0.2'
 
-gem 'activerecord'
+gem 'activerecord', '> 6.1.4', '< 7'
 gem 'async-websocket'
 gem 'dotenv'
 gem 'dotiw'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.3)
-      activesupport (= 6.1.4.3)
-    activerecord (6.1.4.3)
-      activemodel (= 6.1.4.3)
-      activesupport (= 6.1.4.3)
-    activesupport (6.1.4.3)
+    activemodel (6.1.4.4)
+      activesupport (= 6.1.4.4)
+    activerecord (6.1.4.4)
+      activemodel (= 6.1.4.4)
+      activesupport (= 6.1.4.4)
+    activesupport (6.1.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -301,7 +301,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
+  activerecord (> 6.1.4, < 7)
   async-websocket
   byebug
   database_cleaner


### PR DESCRIPTION
There is no sinatra-activerecord for v7 yet, lock at 6 until that has been updated