### PR TITLE
Fix: Lock async gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 ruby '3.1.0'
 
 gem 'activerecord', '> 6.1.4', '< 8'
+gem 'async', '~> 1.30.1'
 gem 'async-websocket'
 gem 'dotenv'
 gem 'dotiw'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (> 6.1.4, < 8)
+  async (~> 1.30.1)
   async-websocket
   byebug
   database_cleaner


### PR DESCRIPTION
an auto update to 2.0.0 broke the helm commands
It worked in tests and locally but failed when deployed
this implies an issue when running on linux and should be monitored
before allowing future updates