### PR TITLE
Fix: Address sidekiq warnings

### DIFF
--- a/config/sidekiq_config.rb
+++ b/config/sidekiq_config.rb
@@ -1,5 +1,5 @@
 sidekiq_config = { url: ENV['JOB_WORKER_URL'] }
-
+Sidekiq.strict_args!
 Sidekiq.configure_server do |config|
   config.redis = sidekiq_config
 end

--- a/lib/worker/test_run_locate.rb
+++ b/lib/worker/test_run_locate.rb
@@ -52,7 +52,7 @@ module Worker
       else
         parsed_result = 'negative - status'
       end
-      @etag = { 'If-None-Match': result.headers[:etag].to_s }
+      @etag = { 'If-None-Match' => result.headers[:etag].to_s }
       parsed_result
     end
 

--- a/spec/lib/workers/test_run_monitor_spec.rb
+++ b/spec/lib/workers/test_run_monitor_spec.rb
@@ -14,7 +14,7 @@ describe Worker::TestRunMonitor do
 
     let(:monitor_url) { 'https://api.github.com/repos/moj/project/job/123' }
     let(:delay) { 45 }
-    let(:data) { { channel: 'test', user: 'test' } }
+    let(:data) { { 'channel' => 'test', 'user' => 'test' } }
     let(:web_url) { 'https://www.github.com/repos/moj/project/job/123' }
     let(:timestamp) { '1595341466.004300' }
     let(:response) { { 'status': 'in_progress' }.to_json }


### PR DESCRIPTION
Ensure data is correctly encoded as json rather than
as a ruby hash when submitting jobs to sidekiq

Ensure sidekiq.strict_args! is set to prevent more
issues being introduced