### PR TITLE
Rubocop: Address Style/StringLiterals

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -235,13 +235,6 @@ Style/MethodCalledOnDoEndBlock:
   Exclude:
     - 'slack-applybot/commands/uat_url.rb'
 
-# Offense count: 1223
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 7
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/Gemfile
+++ b/Gemfile
@@ -1,47 +1,47 @@
-source 'https://rubygems.org'
-ruby '3.1.0'
+source "https://rubygems.org"
+ruby "3.1.0"
 
-gem 'activerecord', '> 6.1.4', '< 8'
-gem 'async', '~> 1.30.1'
-gem 'async-websocket'
-gem 'dotenv'
-gem 'dotiw'
-gem 'kubeclient'
-gem 'openid_connect'
-gem 'pg'
-gem 'puma'
-gem 'rest-client'
-gem 'rotp'
-gem 'rqrcode'
-gem 'sidekiq'
-gem 'sinatra'
-gem 'sinatra-activerecord'
-gem 'slack-ruby-bot'
-gem 'tzinfo-data'
+gem "activerecord", "> 6.1.4", "< 8"
+gem "async", "~> 1.30.1"
+gem "async-websocket"
+gem "dotenv"
+gem "dotiw"
+gem "kubeclient"
+gem "openid_connect"
+gem "pg"
+gem "puma"
+gem "rest-client"
+gem "rotp"
+gem "rqrcode"
+gem "sidekiq"
+gem "sinatra"
+gem "sinatra-activerecord"
+gem "slack-ruby-bot"
+gem "tzinfo-data"
 
 group :development do
-  gem 'guard-rspec'
-  gem 'guard-rubocop'
+  gem "guard-rspec"
+  gem "guard-rubocop"
 end
 
 group :development, :test do
-  gem 'byebug'
-  gem 'foreman'
-  gem 'highline'
-  gem 'pry-byebug'
-  gem 'rake'
-  gem 'rubocop-govuk'
-  gem 'rubocop-performance'
+  gem "byebug"
+  gem "foreman"
+  gem "highline"
+  gem "pry-byebug"
+  gem "rake"
+  gem "rubocop-govuk"
+  gem "rubocop-performance"
 end
 
 group :test do
-  gem 'database_cleaner'
-  gem 'rack-test'
-  gem 'rspec'
-  gem 'shoulda-matchers'
-  gem 'simplecov', require: false
-  gem 'simplecov-rcov'
-  gem 'timecop'
-  gem 'vcr', github: 'vcr/vcr'
-  gem 'webmock'
+  gem "database_cleaner"
+  gem "rack-test"
+  gem "rspec"
+  gem "shoulda-matchers"
+  gem "simplecov", require: false
+  gem "simplecov-rcov"
+  gem "timecop"
+  gem "vcr", github: "vcr/vcr"
+  gem "webmock"
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard :rspec, cmd: 'bundle exec rspec', all_on_start: false do
+guard :rspec, cmd: "bundle exec rspec", all_on_start: false do
   watch(%r{^spec/(.+)_spec\.rb$})
   watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,3 @@
-require 'sinatra/activerecord'
-require 'sinatra/activerecord/rake'
-require './app'
+require "sinatra/activerecord"
+require "sinatra/activerecord/rake"
+require "./app"

--- a/app.rb
+++ b/app.rb
@@ -1,50 +1,50 @@
-require 'sinatra/base'
-require 'sinatra/activerecord'
-require 'slack-ruby-bot'
-require 'sidekiq'
-require 'sidekiq/api'
-require 'sidekiq/web'
-require 'dotenv'
+require "sinatra/base"
+require "sinatra/activerecord"
+require "slack-ruby-bot"
+require "sidekiq"
+require "sidekiq/api"
+require "sidekiq/web"
+require "dotenv"
 
-dot_file = ENV['ENV'].eql?('test') ? '.env.test' : '.env'
+dot_file = ENV["ENV"].eql?("test") ? ".env.test" : ".env"
 Dotenv.load(dot_file)
 
-require 'rotp'
-require 'rqrcode'
-require './lib/apply_service/base'
-require './lib/apply_service_instance/base'
-Dir[File.join('lib/**/*.rb')].sort.each do |f|
-  file = File.join('.', File.dirname(f), File.basename(f))
+require "rotp"
+require "rqrcode"
+require "./lib/apply_service/base"
+require "./lib/apply_service_instance/base"
+Dir[File.join("lib/**/*.rb")].sort.each do |f|
+  file = File.join(".", File.dirname(f), File.basename(f))
   require file
 end
-require './models/user'
-require './config/sidekiq_config'
+require "./models/user"
+require "./config/sidekiq_config"
 class App < Sinatra::Base
   register Sinatra::ActiveRecordExtension
 
   set :show_exceptions, :after_handler
-  set :database_file, 'config/database.yml'
+  set :database_file, "config/database.yml"
   ActiveRecord::Base.logger.level = Logger::WARN if ActiveRecord::Base.logger
   SlackRubyBot::Client.logger.level = Logger::WARN
   SlackRubyBot.configure do |config|
     config.allow_bot_messages = false
   end
-  get '/' do
+  get "/" do
     "
     <h1>LAA-Apply bot, find it in slack</h1>
 		<p><a href='/sidekiq'>Dashboard</a></p>
 		"
   end
 
-  get '/ping' do
+  get "/ping" do
     {
-      build_date: ENV['BUILD_DATE'] || 'Not Available',
-      build_tag: ENV['BUILD_TAG'] || 'Not Available'
+      build_date: ENV["BUILD_DATE"] || "Not Available",
+      build_tag: ENV["BUILD_TAG"] || "Not Available"
     }.to_json
   end
 
-  post '/interactive' do
-    payload = JSON.parse(params['payload'], symbolize_names: true)
+  post "/interactive" do
+    payload = JSON.parse(params["payload"], symbolize_names: true)
     interactive_type = interactive_return(payload)
     send(interactive_type, payload)
   rescue StandardError => e
@@ -52,7 +52,7 @@ class App < Sinatra::Base
   ensure
     # always return empty success response to prevent
     # warnings in slack when buttons are clicked
-    [200, {}, ['']]
+    [200, {}, [""]]
   end
 
   private
@@ -64,30 +64,30 @@ class App < Sinatra::Base
   def new_user_response(values)
     url = values[:response_url]
     action = values[:actions].first
-    payload = new_user_response_json(approve_reject_text(action[:value].eql?('approve')))
-    RestClient.post(url, payload.to_json, { 'Content-Type': 'application/json' })
-    send_file_upload_message(values) if action[:value].eql?('approve')
+    payload = new_user_response_json(approve_reject_text(action[:value].eql?("approve")))
+    RestClient.post(url, payload.to_json, { 'Content-Type': "application/json" })
+    send_file_upload_message(values) if action[:value].eql?("approve")
   end
 
   def send_file_upload_message(values)
-    raw_script = values.dig(:message, :blocks).select { |x| x[:block_id].eql? 'user-script' }.dig(0, :text, :text)
-    script = raw_script.gsub('```', '')
+    raw_script = values.dig(:message, :blocks).select { |x| x[:block_id].eql? "user-script" }.dig(0, :text, :text)
+    script = raw_script.gsub("```", "")
     user = values.dig(:user, :id)
     SendSlackMessage.new.upload_file(message_params(script, user))
   end
 
   def message_params(script, user)
-    { channels: Portal::OutputChannel.is, content: script, filename: 'output.ldif', initial_comment: notify_text(user) }
+    { channels: Portal::OutputChannel.is, content: script, filename: "output.ldif", initial_comment: notify_text(user) }
   end
 
   def notify_text(user)
-    '<!here> can you add the following users? ' \
+    "<!here> can you add the following users? " \
       "<@#{user}> has raised the request and the apply service is ready for them"
   end
 
   def new_user_response_json(message)
     {
-      'replace_original': 'true',
+      'replace_original': "true",
       'text': message
     }
   end

--- a/config/sidekiq_config.rb
+++ b/config/sidekiq_config.rb
@@ -1,4 +1,4 @@
-sidekiq_config = { url: ENV['JOB_WORKER_URL'] }
+sidekiq_config = { url: ENV["JOB_WORKER_URL"] }
 Sidekiq.strict_args!
 Sidekiq.configure_server do |config|
   config.redis = sidekiq_config

--- a/lib/apply_application.rb
+++ b/lib/apply_application.rb
@@ -1,5 +1,5 @@
 class ApplyApplication < ApplyService::Base
   def initialize
-    super('Apply')
+    super("Apply")
   end
 end

--- a/lib/apply_instance.rb
+++ b/lib/apply_instance.rb
@@ -1,5 +1,5 @@
 class ApplyInstance < ApplyServiceInstance::Base
   def initialize(level)
-    super('apply', level)
+    super("apply", level)
   end
 end

--- a/lib/apply_service/base.rb
+++ b/lib/apply_service/base.rb
@@ -1,12 +1,12 @@
 module ApplyService
   class AbstractClassError < RuntimeError
-    def initialize(message = 'ApplyService::Base is an abstract class and cannot be instantiated')
+    def initialize(message = "ApplyService::Base is an abstract class and cannot be instantiated")
       super(message)
     end
   end
 
   class InvalidApplicationError < RuntimeError
-    def initialize(message = 'ApplyService must have a matching _GITHUB_REPO ENV var')
+    def initialize(message = "ApplyService must have a matching _GITHUB_REPO ENV var")
       super(message)
     end
   end

--- a/lib/apply_service_instance/base.rb
+++ b/lib/apply_service_instance/base.rb
@@ -1,18 +1,18 @@
 module ApplyServiceInstance
   class AbstractClassError < RuntimeError
-    def initialize(message = 'ApplyService::Base is an abstract class and cannot be instantiated')
+    def initialize(message = "ApplyService::Base is an abstract class and cannot be instantiated")
       super(message)
     end
   end
 
   class InvalidApplicationError < RuntimeError
-    def initialize(message = 'ApplyInstance must match known APPLICATIONS')
+    def initialize(message = "ApplyInstance must match known APPLICATIONS")
       super(message)
     end
   end
 
   class InvalidInstantiationError < RuntimeError
-    def initialize(message = 'ApplicationInstance requires type and level variables')
+    def initialize(message = "ApplicationInstance requires type and level variables")
       super(message)
     end
   end
@@ -21,8 +21,8 @@ module ApplyServiceInstance
     APPLICATIONS = %w[apply cfe].freeze
     NON_LIVE_ENVS = %w[staging].freeze
     LIVE_ENV_SYNONYMS = %w[production prod live].freeze
-    SERVICE_URL = 'apply-for-legal-aid.service.justice.gov.uk'.freeze
-    PREFIX = 'https://'.freeze
+    SERVICE_URL = "apply-for-legal-aid.service.justice.gov.uk".freeze
+    PREFIX = "https://".freeze
 
     attr_accessor :type, :level
 
@@ -54,7 +54,7 @@ module ApplyServiceInstance
 
     def name
       if LIVE_ENV_SYNONYMS.include?(@level)
-        'production'
+        "production"
       elsif NON_LIVE_ENVS.include?(@level)
         @level
       end

--- a/lib/cfe_application.rb
+++ b/lib/cfe_application.rb
@@ -1,5 +1,5 @@
 class CfeApplication < ApplyService::Base
   def initialize
-    super('CFE')
+    super("CFE")
   end
 end

--- a/lib/cfe_instance.rb
+++ b/lib/cfe_instance.rb
@@ -1,8 +1,8 @@
 class CfeInstance < ApplyServiceInstance::Base
-  SERVICE_URL = 'check-financial-eligibility.apps.live-1.cloud-platform.service.justice.gov.uk'.freeze
+  SERVICE_URL = "check-financial-eligibility.apps.live-1.cloud-platform.service.justice.gov.uk".freeze
 
   def initialize(level)
-    super('cfe', level)
+    super("cfe", level)
   end
 
   def url

--- a/lib/date_display.rb
+++ b/lib/date_display.rb
@@ -11,9 +11,9 @@ class DateDisplay
     count = (Date.today - @date).to_i
     case count
     when 0
-      'today'
+      "today"
     when 1
-      'yesterday'
+      "yesterday"
     else
       "#{count} days ago"
     end

--- a/lib/encryption/service.rb
+++ b/lib/encryption/service.rb
@@ -1,9 +1,9 @@
 module Encryption
   class Service
     KEY = ActiveSupport::KeyGenerator.new(
-      ENV.fetch('SECRET_KEY_BASE')
+      ENV.fetch("SECRET_KEY_BASE")
     ).generate_key(
-      ENV.fetch('ENCRYPTION_SERVICE_SALT'),
+      ENV.fetch("ENCRYPTION_SERVICE_SALT"),
       ActiveSupport::MessageEncryptor.key_len
     ).freeze
 

--- a/lib/github/commits.rb
+++ b/lib/github/commits.rb
@@ -15,8 +15,8 @@ module Github
       #   an amount e.g. ages 6 for 6 commits per application?
       output = []
       parsed_json_data.each do |pr|
-        message = pr['commit']['message'].split("\n").first
-        output << "#{state_icon_for(pr)} #{message}" if message.start_with?('Merge')
+        message = pr["commit"]["message"].split("\n").first
+        output << "#{state_icon_for(pr)} #{message}" if message.start_with?("Merge")
         break if output.count.eql?(5)
       end
       output.join("\n")
@@ -31,10 +31,10 @@ module Github
 
     def state_icon_for(pull_request)
       if @deploy_has_succeeded
-        ':yep:'
+        ":yep:"
       else
-        @deploy_has_succeeded = Github::Status.passed?(pull_request['url'])
-        @deploy_has_succeeded ? ':yep:' : ':nope:'
+        @deploy_has_succeeded = Github::Status.passed?(pull_request["url"])
+        @deploy_has_succeeded ? ":yep:" : ":nope:"
       end
     end
   end

--- a/lib/github/status.rb
+++ b/lib/github/status.rb
@@ -6,11 +6,11 @@ module Github
 
     def call
       raw_data = RestClient.get(@url, GithubValues.headers)
-      JSON.parse(raw_data)['state']
+      JSON.parse(raw_data)["state"]
     end
 
     def self.passed?(commit_url)
-      new(commit_url).call.eql?('success')
+      new(commit_url).call.eql?("success")
     end
   end
 end

--- a/lib/github/team_membership.rb
+++ b/lib/github/team_membership.rb
@@ -1,6 +1,6 @@
 module Github
   class TeamMembership
-    ORG_URL = 'https://api.github.com/orgs/'.freeze
+    ORG_URL = "https://api.github.com/orgs/".freeze
     def initialize(user, group)
       @user = user
       @group = group
@@ -11,7 +11,7 @@ module Github
     end
 
     def call
-      parsed_json_data.map { |x| x['login'] }
+      parsed_json_data.map { |x| x["login"] }
     end
 
     def self.member?(user, group)

--- a/lib/github_values.rb
+++ b/lib/github_values.rb
@@ -1,8 +1,8 @@
 class GithubValues
   def self.headers
     {
-      'content_type': ':json',
-      'accept': 'application/vnd.github.everest-preview+json',
+      'content_type': ":json",
+      'accept': "application/vnd.github.everest-preview+json",
       'Authorization': "token #{ENV['GITHUB_API_TOKEN']}"
     }
   end
@@ -16,10 +16,10 @@ class GithubValues
   end
 
   def self.running_job_url
-    build_url('/actions/workflows/manual-integration-tests.yml/runs?status=in_progress')
+    build_url("/actions/workflows/manual-integration-tests.yml/runs?status=in_progress")
   end
 
   def self.wait_time
-    ENV['GITHUB_WAIT_SECONDS'].to_i || 0
+    ENV["GITHUB_WAIT_SECONDS"].to_i || 0
   end
 end

--- a/lib/helm/github_bits.rb
+++ b/lib/helm/github_bits.rb
@@ -1,5 +1,5 @@
 module GithubBits
-  PREFIX = 'apply-'.freeze
+  PREFIX = "apply-".freeze
 
   private
 
@@ -25,7 +25,7 @@ module GithubBits
 
   def pull_request_data
     @pull_request_data ||= JSON.parse(open_pull_requests.to_json, symbolize_names: true).map do |pr|
-      pr[:head][:ref].gsub(%r{[()\[\]_/\s.]}, '-')
+      pr[:head][:ref].gsub(%r{[()\[\]_/\s.]}, "-")
     end
   end
 

--- a/lib/helm/list.rb
+++ b/lib/helm/list.rb
@@ -1,6 +1,6 @@
 module Helm
   class List
-    def self.call(context = 'apply')
+    def self.call(context = "apply")
       context = "--kube-context #{context}-context"
       raw_output = helm_list_as_json(context)
       releases = parse_releases(raw_output)
@@ -25,11 +25,11 @@ module Helm
       def header
         # "#{parse_name('Name')}#{parse_state('Status')}#{'Date'.ljust(11)}#{parse_data('Branch')}#{parse_data('PR')}"
         [
-          parse_name('Name'),
-          parse_state('Status'),
-          'Date'.ljust(11),
-          'PR'.ljust(3, ' '),
-          parse_data('Branch')
+          parse_name("Name"),
+          parse_state("Status"),
+          "Date".ljust(11),
+          "PR".ljust(3, " "),
+          parse_data("Branch")
         ].join
       end
 
@@ -38,22 +38,22 @@ module Helm
         [
           parse_name(data[0]),
           parse_state(data[1]),
-          parse_date(data[2]).strftime('%Y-%m-%d').ljust(11),
-          (pr_still_exists(data[0]) ? '✔' : '').ljust(3, ' '),
-          parse_data((branch_still_exists(data[0]) ? '✔' : ''))
+          parse_date(data[2]).strftime("%Y-%m-%d").ljust(11),
+          (pr_still_exists(data[0]) ? "✔" : "").ljust(3, " "),
+          parse_data((branch_still_exists(data[0]) ? "✔" : ""))
         ].join
       end
 
       def parse_name(name)
-        name.ljust(40, ' ')
+        name.ljust(40, " ")
       end
 
       def parse_state(state)
-        state.ljust(15, ' ')
+        state.ljust(15, " ")
       end
 
       def parse_data(value)
-        value.ljust(7, ' ')
+        value.ljust(7, " ")
       end
 
       def parse_date(date)

--- a/lib/helm/tidy.rb
+++ b/lib/helm/tidy.rb
@@ -1,8 +1,8 @@
 module Helm
   class Tidy
-    def self.call(context = 'apply')
+    def self.call(context = "apply")
       @context = "--kube-context #{context}-context"
-      @output = ''
+      @output = ""
       @count = 0
       active_uat_namespaces.each do |environment|
         update_output_for(environment)

--- a/lib/kube/client.rb
+++ b/lib/kube/client.rb
@@ -1,6 +1,6 @@
 module Kube
   class Client
-    require 'kubeclient'
+    require "kubeclient"
 
     def self.call
       new.call
@@ -9,7 +9,7 @@ module Kube
     def call
       Kubeclient::Client.new(
         "#{url}/apis/networking.k8s.io",
-        'v1beta1',
+        "v1beta1",
         auth_options: auth_options,
         ssl_options: ssl_options
       )
@@ -18,15 +18,15 @@ module Kube
     private
 
     def auth_options
-      { bearer_token: ENV.fetch('KUBE_TOKEN_APPLY') }
+      { bearer_token: ENV.fetch("KUBE_TOKEN_APPLY") }
     end
 
     def ssl_options
-      { ca_file: ENV.fetch('KUBE_CRT') }
+      { ca_file: ENV.fetch("KUBE_CRT") }
     end
 
     def url
-      ENV.fetch('KUBE_API_URL')
+      ENV.fetch("KUBE_API_URL")
     end
   end
 end

--- a/lib/portal/messages/failure.rb
+++ b/lib/portal/messages/failure.rb
@@ -11,16 +11,16 @@ module Portal
 
       def call
         result = []
-        result << block('The following name(s) could not be matched in CCMS')
+        result << block("The following name(s) could not be matched in CCMS")
         result << block("```#{@names.join("\n")}```")
-        result << block('You will need to confirm their account names and re-submit')
+        result << block("You will need to confirm their account names and re-submit")
         result
       end
 
       private
 
       def block(message)
-        { 'type': 'section', 'text': { 'type': 'mrkdwn', 'text': message } }
+        { 'type': "section", 'text': { 'type': "mrkdwn", 'text': message } }
       end
     end
   end

--- a/lib/portal/messages/success.rb
+++ b/lib/portal/messages/success.rb
@@ -11,32 +11,32 @@ module Portal
 
       def call
         result = []
-        result << block('These user names matched in CCMS')
-        result << block_with_id("```#{@script}```", 'user-script')
-        result << block('Send this script to the new_user channel?')
-        result << action_block('new_user_response') { buttons }
+        result << block("These user names matched in CCMS")
+        result << block_with_id("```#{@script}```", "user-script")
+        result << block("Send this script to the new_user channel?")
+        result << action_block("new_user_response") { buttons }
         result
       end
 
       private
 
       def block(message)
-        { 'type': 'section', 'text': { 'type': 'mrkdwn', 'text': message } }
+        { 'type': "section", 'text': { 'type': "mrkdwn", 'text': message } }
       end
 
       def block_with_id(message, id)
-        { 'block_id': id, 'type': 'section', 'text': { 'type': 'mrkdwn', 'text': message } }
+        { 'block_id': id, 'type': "section", 'text': { 'type': "mrkdwn", 'text': message } }
       end
 
       def action_block(id)
-        { 'block_id': id, 'type': 'actions', elements: yield }
+        { 'block_id': id, 'type': "actions", elements: yield }
       end
 
       def button(style, text)
         {
-          'type': 'button',
+          'type': "button",
           'text': {
-            'type': 'plain_text',
+            'type': "plain_text",
             'emoji': true,
             'text': text.capitalize
           },
@@ -47,8 +47,8 @@ module Portal
 
       def buttons
         buttons = []
-        buttons << button('primary', 'approve')
-        buttons << button('danger', 'reject')
+        buttons << button("primary", "approve")
+        buttons << button("danger", "reject")
         buttons
       end
     end

--- a/lib/portal/name.rb
+++ b/lib/portal/name.rb
@@ -22,7 +22,7 @@ module Portal
     end
 
     def portal_username
-      @portal_username ||= parse_name.upcase.gsub(' ', '%20')
+      @portal_username ||= parse_name.upcase.gsub(" ", "%20")
     end
 
     def display_name

--- a/lib/portal/name_error_message.rb
+++ b/lib/portal/name_error_message.rb
@@ -15,7 +15,7 @@ module Portal
     private
 
     def build_name_errors
-      result = ''
+      result = ""
       @user_list.each do |name|
         result += good_name(name) if name.errors.nil?
         result += bad_name(name) if name.errors.present?

--- a/lib/portal/name_validator.rb
+++ b/lib/portal/name_validator.rb
@@ -1,7 +1,7 @@
 module Portal
   class NameValidator
     def initialize(name)
-      raise 'Name is invalid type' unless name.is_a?(Portal::Name)
+      raise "Name is invalid type" unless name.is_a?(Portal::Name)
 
       @name = name
     end
@@ -18,7 +18,7 @@ module Portal
 
     def validate
       return error_state unless parse_uri
-      return error_state(format_error_message) if raw_response.code != '200'
+      return error_state(format_error_message) if raw_response.code != "200"
 
       @name.portal_name_valid = true
       true
@@ -42,11 +42,11 @@ module Portal
     end
 
     def provider_details_url
-      File.join(ENV['PROVIDER_DETAILS_URL'], @name.portal_username)
+      File.join(ENV["PROVIDER_DETAILS_URL"], @name.portal_username)
     end
 
     def format_error_message
-      if raw_response.code == '404'
+      if raw_response.code == "404"
         "User #{@name.portal_username} not known to CCMS"
       else
         "Bad response from Provider Details API: HTTP status #{raw_response.code}"

--- a/lib/portal/names/collator.rb
+++ b/lib/portal/names/collator.rb
@@ -6,7 +6,7 @@ module Portal
 
       def initialize(names)
         # this should be passed the raw match data
-        @names = names.split(',').map(&:strip).map(&:upcase)
+        @names = names.split(",").map(&:strip).map(&:upcase)
         @status = :created
         process
       end

--- a/lib/portal/output_channel.rb
+++ b/lib/portal/output_channel.rb
@@ -5,16 +5,16 @@ module Portal
     end
 
     def valid?
-      channel_name = SendSlackMessage.new.conversations_info(channel: @current_channel)['channel']['name']
-      channel_name.eql?(ENV['USER_OUTPUT_CHANNEL'])
+      channel_name = SendSlackMessage.new.conversations_info(channel: @current_channel)["channel"]["name"]
+      channel_name.eql?(ENV["USER_OUTPUT_CHANNEL"])
     end
 
     def self.is
-      ENV['USER_OUTPUT_CHANNEL']
+      ENV["USER_OUTPUT_CHANNEL"]
     end
 
     def self.display_name
-      SendSlackMessage.new.conversations_info(channel: is)['channel']['name']
+      SendSlackMessage.new.conversations_info(channel: is)["channel"]["name"]
     end
   end
 end

--- a/lib/send_slack_message.rb
+++ b/lib/send_slack_message.rb
@@ -1,8 +1,8 @@
 class SendSlackMessage
   def initialize
     Slack.configure do |config|
-      config.token = ENV['SLACK_API_TOKEN']
-      raise 'Missing ENV[SLACK_API_TOKEN]!' unless config.token
+      config.token = ENV["SLACK_API_TOKEN"]
+      raise "Missing ENV[SLACK_API_TOKEN]!" unless config.token
     end
     check_connection
   end

--- a/lib/slack/block_builder.rb
+++ b/lib/slack/block_builder.rb
@@ -15,7 +15,7 @@ module Slack
     end
 
     def call(state, **args)
-      raise 'State error' unless STATES.include?(state)
+      raise "State error" unless STATES.include?(state)
 
       @args = args
       @block_id = state.to_s
@@ -28,7 +28,7 @@ module Slack
     private
 
     def start
-      ':spinner2: A test run has been requested from Github'
+      ":spinner2: A test run has been requested from Github"
     end
 
     def searching
@@ -41,17 +41,17 @@ module Slack
     end
 
     def complete
-      result = @args[:result] ? 'Successfully' : 'Failed'
-      icon = @args[:result] ? 'yep' : 'nope'
+      result = @args[:result] ? "Successfully" : "Failed"
+      icon = @args[:result] ? "yep" : "nope"
       "*Test run has completed*\n:#{icon}: <#{@args[:web_url]}|#{result}>"
     end
 
     def block
       {
-        'type': 'section',
+        'type': "section",
         'block_id': @block_id.to_s,
         'text': {
-          'type': 'mrkdwn',
+          'type': "mrkdwn",
           'text': @message.to_s
         }
       }

--- a/lib/token_generator.rb
+++ b/lib/token_generator.rb
@@ -1,14 +1,14 @@
 class TokenGenerator
-  require 'ostruct'
-  require 'base64'
-  require 'json'
+  require "ostruct"
+  require "base64"
+  require "json"
 
   def self.call(slack_id)
     new.call(slack_id)
   end
 
   def call(slack_id)
-    token = { slack_id: slack_id, expires_at: Time.now + (10 * 60), secret: ENV.fetch('SECRET_KEY_BASE') }
+    token = { slack_id: slack_id, expires_at: Time.now + (10 * 60), secret: ENV.fetch("SECRET_KEY_BASE") }
     Base64.urlsafe_encode64(token.to_json)
   end
 end

--- a/lib/worker/test_run_locate.rb
+++ b/lib/worker/test_run_locate.rb
@@ -1,4 +1,4 @@
-require 'dotiw'
+require "dotiw"
 module Worker
   class TestRunLocate
     include Sidekiq::Worker
@@ -28,7 +28,7 @@ module Worker
     end
 
     def update_and_monitor(channel, message_ts, running_job)
-      polling_url = running_job['workflow_runs'][0]['url']
+      polling_url = running_job["workflow_runs"][0]["url"]
       web_url = get_web_url_from(running_job)
       TestRunMonitor.perform_in(45, polling_url, 30, channel, web_url, message_ts)
       send_message(Slack::BlockBuilder.call(:waiting, web_url: web_url), channel, message_ts)
@@ -48,11 +48,11 @@ module Worker
       result = rest_client_get_response(GithubValues.running_job_url, GithubValues.headers.merge(retry_headers || {}))
       if result.code.eql?(200)
         json_result = JSON.parse(result)
-        parsed_result = json_result['total_count'].positive? ? json_result : negative_result(json_result)
+        parsed_result = json_result["total_count"].positive? ? json_result : negative_result(json_result)
       else
-        parsed_result = 'negative - status'
+        parsed_result = "negative - status"
       end
-      @etag = { 'If-None-Match' => result.headers[:etag].to_s }
+      @etag = { "If-None-Match" => result.headers[:etag].to_s }
       parsed_result
     end
 
@@ -61,7 +61,7 @@ module Worker
     end
 
     def get_web_url_from(running_job)
-      job_data = rest_client_get_response(running_job['workflow_runs'][0]['jobs_url'])
+      job_data = rest_client_get_response(running_job["workflow_runs"][0]["jobs_url"])
       "#{JSON.parse(job_data)['jobs'][0]['html_url']}?check_suite_focus=true"
     end
 

--- a/lib/worker/test_run_monitor.rb
+++ b/lib/worker/test_run_monitor.rb
@@ -1,12 +1,12 @@
 module Worker
   class TestRunMonitor
-    require 'rest-client'
+    require "rest-client"
     include Sidekiq::Worker
 
     def perform(monitor_url, delay, channel, web_url, message_ts)
       result = call_github(monitor_url)
-      if result['status'].eql?('completed')
-        block = Slack::BlockBuilder.call(:complete, result: result['conclusion'].eql?('success'), web_url: web_url)
+      if result["status"].eql?("completed")
+        block = Slack::BlockBuilder.call(:complete, result: result["conclusion"].eql?("success"), web_url: web_url)
         SendSlackMessage.new.update({ ts: message_ts, channel: channel, as_user: true }.merge(block))
       else
         TestRunMonitor.perform_in(delay, monitor_url, delay / 2, channel, web_url, message_ts)

--- a/lib/worker/test_run_start.rb
+++ b/lib/worker/test_run_start.rb
@@ -1,7 +1,7 @@
 module Worker
   class TestRunStart
     include Sidekiq::Worker
-    require 'rest-client'
+    require "rest-client"
 
     class GithubStartJobError < StandardError; end
 
@@ -12,7 +12,7 @@ module Worker
       message = SendSlackMessage.new.generic(
         { channel: @channel, as_user: true }.merge(Slack::BlockBuilder.call(:start))
       )
-      TestRunLocate.perform_in(GithubValues.wait_time, @channel, message['ts'], 1, {})
+      TestRunLocate.perform_in(GithubValues.wait_time, @channel, message["ts"], 1, {})
     rescue GithubStartJobError => e
       SendSlackMessage.new.generic(
         { channel: @channel, as_user: true }.merge(Slack::BlockBuilder.start_error(e.message))
@@ -22,12 +22,12 @@ module Worker
     private
 
     def build_data(data)
-      @channel = data['channel']
-      @user_id = data['user']
+      @channel = data["channel"]
+      @user_id = data["user"]
     end
 
     def start_test_run
-      dispatch_url = GithubValues.build_url('/dispatches')
+      dispatch_url = GithubValues.build_url("/dispatches")
       payload = build_payload.to_json
       RestClient.post(dispatch_url, payload, GithubValues.headers)
     rescue StandardError => e
@@ -39,7 +39,7 @@ module Worker
     end
 
     def build_payload
-      { 'event_type': 'manual-trigger', 'client_payload': { user: user_name, client: 'apply_bot' } }
+      { 'event_type': "manual-trigger", 'client_payload': { user: user_name, client: "apply_bot" } }
     end
   end
 end

--- a/scripts/ecr_cleanup.rb
+++ b/scripts/ecr_cleanup.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
-require 'json'
-require 'date'
+require "json"
+require "date"
 
 class Summary
   def initialize
@@ -17,16 +17,16 @@ class Summary
 end
 
 def image_redis?(image)
-  image['imageTags']&.join("\t")&.match?(/redis/)
+  image["imageTags"]&.join("\t")&.match?(/redis/)
 end
 
 def image_in_use?(image)
-  image['imageTags']&.join("\t")&.match?(ENV.fetch('GITHUB_SHA', '-'))
+  image["imageTags"]&.join("\t")&.match?(ENV.fetch("GITHUB_SHA", "-"))
 end
 
 def image_out_of_date?(image)
   delete_if_older_than = 2 # days
-  date_pushed = DateTime.strptime(image['imagePushedAt'].to_s, '%s')
+  date_pushed = DateTime.strptime(image["imagePushedAt"].to_s, "%s")
   @summary.add(date_pushed.to_date.to_s)
   age_in_days = (DateTime.now - date_pushed).to_i
   age_in_days > delete_if_older_than
@@ -36,25 +36,25 @@ def image_deletable(image)
   [image_out_of_date?(image), !image_in_use?(image), !image_redis?(image)].all?
 end
 
-repo = 'laa-apply-for-legal-aid/laa-apply-bot'
-aws_prefix = 'aws --region eu-west-2 ecr'
-puts 'Identifying images to delete'
+repo = "laa-apply-for-legal-aid/laa-apply-bot"
+aws_prefix = "aws --region eu-west-2 ecr"
+puts "Identifying images to delete"
 json_output = `#{aws_prefix} describe-images --repository-name #{repo} --output json`
-images = JSON.parse(json_output)['imageDetails']
+images = JSON.parse(json_output)["imageDetails"]
 
 images_to_delete = []
 @summary = Summary.new
 images.each { |i| images_to_delete << i if image_deletable(i) }
 
 if images_to_delete.empty?
-  puts 'Nothing to delete'
+  puts "Nothing to delete"
 else
-  puts 'Deleting images'
+  puts "Deleting images"
   images_to_delete.each_slice(100) do |batch|
-    image_ids = batch.map { |i| "imageDigest=#{i['imageDigest']}" }.join(' ')
+    image_ids = batch.map { |i| "imageDigest=#{i['imageDigest']}" }.join(" ")
     `#{aws_prefix} batch-delete-image --repository-name #{repo} --image-ids #{image_ids}`
   end
 
 end
 puts @summary.output
-puts 'Done!'
+puts "Done!"

--- a/slack-applybot/bot.rb
+++ b/slack-applybot/bot.rb
@@ -2,70 +2,70 @@ module SlackApplybot
   class Bot < SlackRubyBot::Bot
     COMMANDS = [
       {
-        name: 'add users',
-        desc: '`@apply-bot add users <comma separated names>`',
+        name: "add users",
+        desc: "`@apply-bot add users <comma separated names>`",
         long_desc: <<~ADDUSER.chomp
           Generates a portal user script in the #{ENV['USER_OUTPUT_CHANNEL']} channel regardless of where you ask
           e.g. `@applybot add user BENREID` or `@applybot add users benreid, NEETADESOR`
         ADDUSER
       },
       {
-        name: 'ages',
-        desc: '`@apply-bot ages`',
-        long_desc: 'Shows the time since both applications were last deployed'
+        name: "ages",
+        desc: "`@apply-bot ages`",
+        long_desc: "Shows the time since both applications were last deployed"
       },
       {
-        name: 'details',
-        desc: '`@apply-bot <application> details <environment>` e.g. `@apply-bot cfe details staging`',
-        long_desc: 'Shows the ping details page for the selected application and non-uat environments, '\
-                   'e.g.  `@apply-bot apply details staging` or `@apply-bot cfe details production`'
+        name: "details",
+        desc: "`@apply-bot <application> details <environment>` e.g. `@apply-bot cfe details staging`",
+        long_desc: "Shows the ping details page for the selected application and non-uat environments, "\
+                   "e.g.  `@apply-bot apply details staging` or `@apply-bot cfe details production`"
       },
       {
-        name: 'run tests',
-        desc: '`@apply-bot run tests`',
+        name: "run tests",
+        desc: "`@apply-bot run tests`",
         long_desc: <<~RUNTESTS.chomp
           Starts a remote test run on the linked github repo it will respond to you with a link
           to the running job on github.  When the job finishes it will message you with the result
         RUNTESTS
       },
       {
-        name: 'uat urls',
-        desc: '`@apply-bot uat urls`',
-        long_desc: 'Returns a list of all Apply UAT urls currently available'
+        name: "uat urls",
+        desc: "`@apply-bot uat urls`",
+        long_desc: "Returns a list of all Apply UAT urls currently available"
       },
       {
-        name: 'uat url',
-        desc: '`@apply-bot uat url <branch> e.g. @apply-bot uat url ap-999`',
-        long_desc: 'This will either show the uat url for the specified branch or, if it cannot be matched,'\
-                   'return an apology and the list of all available uat environments'
+        name: "uat url",
+        desc: "`@apply-bot uat url <branch> e.g. @apply-bot uat url ap-999`",
+        long_desc: "This will either show the uat url for the specified branch or, if it cannot be matched,"\
+                   "return an apology and the list of all available uat environments"
       },
       {
-        name: 'helm',
-        desc: '`@apply-bot helm <instruction>` e.g. `@apply-bot helm list`',
-        long_desc: 'This will run a helm command against the UAT helm kubernetes cluster ' \
+        name: "helm",
+        desc: "`@apply-bot helm <instruction>` e.g. `@apply-bot helm list`",
+        long_desc: "This will run a helm command against the UAT helm kubernetes cluster " \
                    "currently supported instructions are: `list`, `tidy` & `delete` \n " \
-                   '- `list` and `tidy` can be followed by an optional (default is `apply`) context ' \
+                   "- `list` and `tidy` can be followed by an optional (default is `apply`) context " \
                    "current values are `apply`, `cfe`, `hmrc` or `lfa` \n" \
-                   '- `delete` will need to be followed by a 2fa code, see `help 2fa`, but does not ' \
-                   'currently support contexts and will default to, and only work on, apply'
+                   "- `delete` will need to be followed by a 2fa code, see `help 2fa`, but does not " \
+                   "currently support contexts and will default to, and only work on, apply"
       },
       {
-        name: 'github',
-        desc: '`@apply-bot github <instruction>` e.g. `@apply-bot github link <your github name>`',
-        long_desc: 'This will run a command that links your current slack account ' \
-                   'with a github account, currently supported instruction is: `link`'
+        name: "github",
+        desc: "`@apply-bot github <instruction>` e.g. `@apply-bot github link <your github name>`",
+        long_desc: "This will run a command that links your current slack account " \
+                   "with a github account, currently supported instruction is: `link`"
       },
       {
-        name: '2fa',
-        desc: '`@apply-bot 2fa <instruction>` e.g. `@apply-bot 2fa setup`',
-        long_desc: 'This will enable two-factor authentication for you to issue potentially ' \
-                   'destructive commands, currently supported instructions are: `setup`, `confirm`'
+        name: "2fa",
+        desc: "`@apply-bot 2fa <instruction>` e.g. `@apply-bot 2fa setup`",
+        long_desc: "This will enable two-factor authentication for you to issue potentially " \
+                   "destructive commands, currently supported instructions are: `setup`, `confirm`"
       }
     ].freeze
 
     help do
-      title 'LAA Apply Bot'
-      desc 'This bot assists the LAA Apply team to administer their applications'
+      title "LAA Apply Bot"
+      desc "This bot assists the LAA Apply team to administer their applications"
 
       COMMANDS.each do |command|
         command command[:name] do

--- a/slack-applybot/commands/_channel_validity.rb
+++ b/slack-applybot/commands/_channel_validity.rb
@@ -2,7 +2,7 @@ module ChannelValidity
   ERROR_MESSAGE = "Sorry <@|USERNAME|>, I don't understand that command!".freeze
 
   class PublicError < RuntimeError
-    def initialize(channel:, message: 'Channel is too public')
+    def initialize(channel:, message: "Channel is too public")
       SendSlackMessage.new.generic(channel: channel, as_user: true, text: message)
       super(message)
     end
@@ -17,19 +17,19 @@ module ChannelValidity
 
   def channel_is_valid?
     @channel_info = SendSlackMessage.new.conversations_info(channel: @data.channel)
-    return true if @channel_info['channel']['is_im']
+    return true if @channel_info["channel"]["is_im"]
 
-    channel_name = @channel_info['channel']['name']
-    ENV['ALLOWED_CHANNEL_LIST'].include?(channel_name)
+    channel_name = @channel_info["channel"]["name"]
+    ENV["ALLOWED_CHANNEL_LIST"].include?(channel_name)
   end
 
   def channel_is_not_dm?
     @channel_info = SendSlackMessage.new.conversations_info(channel: @data.channel)
-    @channel_info['channel']['is_im']&.eql?(false)
+    @channel_info["channel"]["is_im"]&.eql?(false)
   end
 
   def error_message
-    ERROR_MESSAGE.sub('|USERNAME|', @data.user)
+    ERROR_MESSAGE.sub("|USERNAME|", @data.user)
   end
 
   def user_is_valid?

--- a/slack-applybot/commands/_two_factor_auth_shared.rb
+++ b/slack-applybot/commands/_two_factor_auth_shared.rb
@@ -1,5 +1,5 @@
 module TwoFactorAuthShared
-  require 'rotp'
+  require "rotp"
 
   private
 
@@ -8,7 +8,7 @@ module TwoFactorAuthShared
   end
 
   def validate(user, otp)
-    totp = ROTP::TOTP.new(Encryption::Service.decrypt(user.encrypted_2fa_secret), issuer: ENV.fetch('SERVICE_NAME'))
+    totp = ROTP::TOTP.new(Encryption::Service.decrypt(user.encrypted_2fa_secret), issuer: ENV.fetch("SERVICE_NAME"))
     totp.verify(otp)
   end
 end

--- a/slack-applybot/commands/_user_command.rb
+++ b/slack-applybot/commands/_user_command.rb
@@ -4,7 +4,7 @@ module UserCommand
   end
 
   def user_dm_channel(client)
-    client.web_client.conversations_open(users: user.slack_id)['channel']['id']
+    client.web_client.conversations_open(users: user.slack_id)["channel"]["id"]
   end
 
   def user_has_github_linked?

--- a/slack-applybot/commands/add_user.rb
+++ b/slack-applybot/commands/add_user.rb
@@ -3,7 +3,7 @@ module SlackApplybot
     class AddUser < SlackRubyBot::Commands::Base
       command(/add (user|users)/) do |client, data, match|
         client.typing(channel: data.channel)
-        Portal::UserRequester.initiate(match['expression'], data.channel)
+        Portal::UserRequester.initiate(match["expression"], data.channel)
       end
     end
   end

--- a/slack-applybot/commands/ages.rb
+++ b/slack-applybot/commands/ages.rb
@@ -1,14 +1,14 @@
 module SlackApplybot
   module Commands
     class Ages < SlackRubyBot::Commands::Base
-      command 'ages' do |client, data, _match|
+      command "ages" do |client, data, _match|
         @client = client
         @data = data
 
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
-        apply_message = age_message('Apply')
-        cfe_message = age_message('CFE')
+        apply_message = age_message("Apply")
+        cfe_message = age_message("CFE")
         # get master data from github?
         message_text = "#{apply_message}\n#{cfe_message}"
         client.say(channel: data.channel, text: message_text)
@@ -21,8 +21,8 @@ module SlackApplybot
 
         def age_message(app)
           application = "#{app.humanize}Application".constantize.new
-          instance = "#{app.humanize}Instance".constantize.new('production')
-          deploy_date = Date.parse(instance.ping_data['build_date'])
+          instance = "#{app.humanize}Instance".constantize.new("production")
+          deploy_date = Date.parse(instance.ping_data["build_date"])
           <<~OUTPUT.chomp
             #{app} was deployed #{DateDisplay.call(deploy_date)}
             #{::Github::Commits.call(application)}

--- a/slack-applybot/commands/deploy_reminder.rb
+++ b/slack-applybot/commands/deploy_reminder.rb
@@ -2,13 +2,13 @@ module SlackApplybot
   module Commands
     class DeployReminder < SlackRubyBot::Commands::Base
       def self.app_name(match)
-        match[2].present? ? match[2] : 'Apply'
+        match[2].present? ? match[2] : "Apply"
       end
 
       attachment(/(\S*) has a pending ?(\S*)? production approval for master/) do |_client, data, match|
         result = {
           channel: data.channel,
-          channel_name: SendSlackMessage.new.conversations_info(channel: data.channel)['channel']['name'],
+          channel_name: SendSlackMessage.new.conversations_info(channel: data.channel)["channel"]["name"],
           proposal: "Find slack id for #{match[1]} and remind them to deploy #{app_name(match)} to production"
         }
         SlackRubyBot::Client.logger.warn(result.to_json)

--- a/slack-applybot/commands/details.rb
+++ b/slack-applybot/commands/details.rb
@@ -1,13 +1,13 @@
 module SlackApplybot
   module Commands
     class Details < SlackRubyBot::Commands::Base
-      command 'apply', 'cfe', /details/ do |client, data, match|
+      command "apply", "cfe", /details/ do |client, data, match|
         @client = client
         @data = data
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
-        app = match['command'].downcase
-        env = match['expression'].sub('details', '').strip.downcase
+        app = match["command"].downcase
+        env = match["expression"].sub("details", "").strip.downcase
         return unless env.split(/,\s|\s/).count.eql?(1)
 
         environment = "#{app.humanize}Instance".constantize.new(env)

--- a/slack-applybot/commands/github.rb
+++ b/slack-applybot/commands/github.rb
@@ -1,18 +1,18 @@
 module SlackApplybot
   module Commands
     class Github < SlackRubyBot::Commands::Base
-      command 'github' do |client, data, match|
+      command "github" do |client, data, match|
         @client = client
         @data = data
         @user = user
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
         client.typing(channel: data.channel)
-        message = case match['expression']&.downcase
+        message = case match["expression"]&.downcase
                   when /^link/
                     process_link_request(match)
                   when nil
-                    SlackRubyBot::Commands::Support::Help.instance.command_full_desc('github')
+                    SlackRubyBot::Commands::Support::Help.instance.command_full_desc("github")
                   else
                     "You called `github` with `#{match['expression']}`. This is not supported."
                   end
@@ -24,13 +24,13 @@ module SlackApplybot
         include UserCommand
 
         def process_link_request(match)
-          parts = match['expression'].split - ['link']
+          parts = match["expression"].split - ["link"]
           if parts.empty?
-            'Github ID not provided, please call as `github link <github_user_name>`'
+            "Github ID not provided, please call as `github link <github_user_name>`"
           elsif link_account(parts[0])
-            'Github link successfully configured'
+            "Github link successfully configured"
           else
-            'This github user is not in the correct team, please request access'
+            "This github user is not in the correct team, please request access"
           end
         end
 
@@ -40,7 +40,7 @@ module SlackApplybot
         end
 
         def github_name_in_group?(github_name)
-          ::Github::TeamMembership.member?(github_name, 'laa-apply-for-legal-aid')
+          ::Github::TeamMembership.member?(github_name, "laa-apply-for-legal-aid")
         end
       end
     end

--- a/slack-applybot/commands/helm.rb
+++ b/slack-applybot/commands/helm.rb
@@ -1,19 +1,19 @@
 module SlackApplybot
   module Commands
     class Helm < SlackRubyBot::Commands::Base
-      command 'helm' do |client, data, match|
+      command "helm" do |client, data, match|
         @client = client
         @data = data
         @user = user
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
-        message = case match['expression']
+        message = case match["expression"]
                   when /^list/, /^tidy/
                     process_command(match)
                   when /^delete/
                     process_delete(match)
                   when nil
-                    SlackRubyBot::Commands::Support::Help.instance.command_full_desc('helm')
+                    SlackRubyBot::Commands::Support::Help.instance.command_full_desc("helm")
                   else
                     "You called `helm` with `#{match['expression']}`. This is not supported."
                   end
@@ -27,22 +27,22 @@ module SlackApplybot
         include UserCommand
 
         def process_delete(match)
-          parts = match['expression'].split - ['delete']
+          parts = match["expression"].split - ["delete"]
           if parts.empty?
-            'Unable to delete - insufficient data, please call as `helm delete name-of-release 000000`'
+            "Unable to delete - insufficient data, please call as `helm delete name-of-release 000000`"
           elsif parts.count.eql?(1)
-            'OTP password not provided, please call as `helm delete name-of-release 000000`'
+            "OTP password not provided, please call as `helm delete name-of-release 000000`"
           elsif validate_otp_part(parts[1])
-            ::Helm::Delete.call(parts[0]) ? "#{parts[0]} deleted" : 'Unable to delete'
+            ::Helm::Delete.call(parts[0]) ? "#{parts[0]} deleted" : "Unable to delete"
           else
-            'OTP password did not match, please check your authenticator app'
+            "OTP password did not match, please check your authenticator app"
           end
         end
 
         def process_command(match)
-          parts = match['expression'].split
+          parts = match["expression"].split
           command = parts[0].capitalize
-          context = parts[1] || 'apply'
+          context = parts[1] || "apply"
           if validate_context(context)
             "::Helm::#{command}".constantize.call(context)
           else

--- a/slack-applybot/commands/help.rb
+++ b/slack-applybot/commands/help.rb
@@ -1,7 +1,7 @@
 module SlackRubyBot
   module Commands
     class Help < Base
-      command 'help' do |client, data, match|
+      command "help" do |client, data, match|
         @client = client
         @data = data
         @command = match[:expression]
@@ -28,7 +28,7 @@ module SlackRubyBot
         end
 
         def text_when_channel_is_shared
-          Support::Help.instance.command_full_desc('add users')
+          Support::Help.instance.command_full_desc("add users")
         end
 
         def general_text

--- a/slack-applybot/commands/integration_tests.rb
+++ b/slack-applybot/commands/integration_tests.rb
@@ -1,7 +1,7 @@
 module SlackApplybot
   module Commands
     class IntegrationTests < SlackRubyBot::Commands::Base
-      command 'run tests' do |client, data, _match|
+      command "run tests" do |client, data, _match|
         @client = client
         @data = data
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?

--- a/slack-applybot/commands/two_factor_auth.rb
+++ b/slack-applybot/commands/two_factor_auth.rb
@@ -1,18 +1,18 @@
 module SlackApplybot
   module Commands
     class TwoFactorAuth < SlackRubyBot::Commands::Base
-      require 'rotp'
-      require 'rqrcode'
+      require "rotp"
+      require "rqrcode"
 
-      command '2fa' do |client, data, match|
+      command "2fa" do |client, data, match|
         @client = client
         @data = data
         @user = user
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
         client.typing(channel: data.channel)
-        case match['expression']&.downcase
-        when 'setup'
+        case match["expression"]&.downcase
+        when "setup"
           user_dm = user_dm_channel(client)
           if user_has_github_linked?
             send_qr_message(user_dm)
@@ -35,18 +35,18 @@ module SlackApplybot
         include UserCommand
 
         def process_confirmation(match)
-          parts = match['expression'].split - ['confirm']
+          parts = match["expression"].split - ["confirm"]
           if parts.empty?
-            'OTP password not provided, please call as `2fa confirm 000000`'
+            "OTP password not provided, please call as `2fa confirm 000000`"
           elsif validate_otp_part(parts[0])
-            'OTP has been successfully configured'
+            "OTP has been successfully configured"
           else
-            'OTP password did not match, please check your authenticator app'
+            "OTP password did not match, please check your authenticator app"
           end
         end
 
         def send_dm_to_link_github(channel)
-          message = 'You need to link your github account before you can setup 2FA'
+          message = "You need to link your github account before you can setup 2FA"
           @client.say(channel: channel, text: message)
         end
 
@@ -56,15 +56,15 @@ module SlackApplybot
           SendSlackMessage.new.upload_file(
             channels: channel,
             as_user: true,
-            file: Faraday::FilePart.new(StringIO.new(build_qr_code(token)), 'image/png', 'apply_bot_qr.png'),
-            title: 'Your apply-bot QR',
-            initial_comment: 'Scan with an authenticator app'
+            file: Faraday::FilePart.new(StringIO.new(build_qr_code(token)), "image/png", "apply_bot_qr.png"),
+            title: "Your apply-bot QR",
+            initial_comment: "Scan with an authenticator app"
           )
         end
 
         def build_qr_code(token)
-          totp = ROTP::TOTP.new(token, issuer: ENV.fetch('SERVICE_NAME'))
-          qrcode = RQRCode::QRCode.new(totp.provisioning_uri(ENV.fetch('SERVICE_EMAIL')))
+          totp = ROTP::TOTP.new(token, issuer: ENV.fetch("SERVICE_NAME"))
+          qrcode = RQRCode::QRCode.new(totp.provisioning_uri(ENV.fetch("SERVICE_EMAIL")))
 
           qrcode.as_png(
             border_modules: 1,

--- a/slack-applybot/commands/uat_url.rb
+++ b/slack-applybot/commands/uat_url.rb
@@ -1,18 +1,18 @@
 module SlackApplybot
   module Commands
     class UatUrl < SlackRubyBot::Commands::Base
-      command 'uat' do |client, data, match|
+      command "uat" do |client, data, match|
         @client = client
         @data = data
         @user = user
         raise ChannelValidity::PublicError.new(message: error_message, channel: @data.channel) unless channel_is_valid?
 
-        ingresses = Kube::Ingresses.call('laa-apply-for-legalaid-uat')
-        message = case match['expression']&.downcase
+        ingresses = Kube::Ingresses.call("laa-apply-for-legalaid-uat")
+        message = case match["expression"]&.downcase
                   when /^urls$/
                     "Apply UAT urls:\n#{display(ingresses)}"
                   when /^url/
-                    branch = match['expression'].gsub(/url /, '')
+                    branch = match["expression"].gsub(/url /, "")
                     single_match = ingresses.find { |e| e.starts_with?(branch) }
                     if single_match
                       "Branch <https://#{single_match}|#{branch}> is available"

--- a/slack_applybot.rb
+++ b/slack_applybot.rb
@@ -1,11 +1,11 @@
-require 'slack-ruby-bot'
-require 'sidekiq'
-require './slack-applybot/bot'
-Dir[File.join('slack-applybot/commands/*.rb')].sort.each do |f|
-  file = File.join('.', File.dirname(f), File.basename(f))
+require "slack-ruby-bot"
+require "sidekiq"
+require "./slack-applybot/bot"
+Dir[File.join("slack-applybot/commands/*.rb")].sort.each do |f|
+  file = File.join(".", File.dirname(f), File.basename(f))
   require file
 end
-require './lib/github_values'
-require './lib/worker/test_run_start'
-require './lib/worker/test_run_locate'
-require './lib/worker/test_run_monitor'
+require "./lib/github_values"
+require "./lib/worker/test_run_start"
+require "./lib/worker/test_run_locate"
+require "./lib/worker/test_run_monitor"

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1,75 +1,75 @@
-require 'spec_helper'
-require 'rack/test'
+require "spec_helper"
+require "rack/test"
 
-describe 'Sinatra App' do
+describe "Sinatra App" do
   include Rack::Test::Methods
 
   def app
     App.new
   end
 
-  it 'displays home page' do
-    get '/'
-    expect(last_response.body).to include('LAA-Apply bot')
+  it "displays home page" do
+    get "/"
+    expect(last_response.body).to include("LAA-Apply bot")
   end
 
-  describe '#ping' do
+  describe "#ping" do
     before do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('BUILD_DATE').and_return(build_date)
-      allow(ENV).to receive(:[]).with('BUILD_TAG').and_return(build_tag)
-      get '/ping'
+      allow(ENV).to receive(:[]).with("BUILD_DATE").and_return(build_date)
+      allow(ENV).to receive(:[]).with("BUILD_TAG").and_return(build_tag)
+      get "/ping"
     end
     let(:build_date) { nil }
     let(:build_tag) { nil }
 
-    context 'when environment variables set' do
-      let(:build_date) { '20150721' }
-      let(:build_tag) { 'test' }
+    context "when environment variables set" do
+      let(:build_date) { "20150721" }
+      let(:build_tag) { "test" }
 
       let(:expected_json) do
         {
-          'build_date' => '20150721',
-          'build_tag' => 'test'
+          "build_date" => "20150721",
+          "build_tag" => "test"
         }
       end
 
-      it 'returns JSON with app information' do
+      it "returns JSON with app information" do
         expect(JSON.parse(last_response.body)).to eq(expected_json)
       end
     end
 
-    context 'when environment variables not set' do
+    context "when environment variables not set" do
       it 'returns "Not Available"' do
-        expect(JSON.parse(last_response.body).values).to be_all('Not Available')
+        expect(JSON.parse(last_response.body).values).to be_all("Not Available")
       end
     end
 
-    it 'returns ok http status' do
+    it "returns ok http status" do
       expect(last_response.status).to eq 200
     end
   end
 
-  describe '/interactive' do
-    context 'when general data is posted to interactive' do
-      let(:submitted_data) { { data: 'something' } }
+  describe "/interactive" do
+    context "when general data is posted to interactive" do
+      let(:submitted_data) { { data: "something" } }
 
-      it 'is swallowed' do
+      it "is swallowed" do
         expect(SlackRubyBot::Client.logger).to receive(:warn).once
-        post '/interactive', submitted_data
-        expect(last_response.body).to eql ''
+        post "/interactive", submitted_data
+        expect(last_response.body).to eql ""
         expect(last_response.status).to eq 200
       end
     end
 
-    context 'when the data is a portal user response' do
+    context "when the data is a portal user response" do
       before do
         stub_request(:post, %r{\Ahttps://hooks.slack.com/actions/.*\z}).to_return(status: 200)
       end
 
-      context 'and they accept' do
+      context "and they accept" do
         let(:submitted_data) do
-          { 'payload' =>
+          { "payload" =>
               '{"type":"block_actions","user":{"id":"AB123DEFG","username":"test.user","name":"test.user"},' \
               '"message":{"bot_id":"B011ZBY8UJ1",' \
               '"type":"message","text":"This content can\\u2019t be displayed.","user":"U011L1K39JT",' \
@@ -90,16 +90,16 @@ describe 'Sinatra App' do
               '"action_ts":"1637072709.069557"}]}' }
         end
 
-        it 'a post to replace the text is made' do
+        it "a post to replace the text is made" do
           expect_any_instance_of(SendSlackMessage).to receive(:upload_file)
-          post '/interactive', submitted_data
+          post "/interactive", submitted_data
           expect(a_request(:post, %r{\Ahttps://hooks.slack.com/actions/.*\z})).to have_been_made.times(1)
         end
       end
 
-      context 'and they reject' do
+      context "and they reject" do
         let(:submitted_data) do
-          { 'payload' =>
+          { "payload" =>
               '{"type":"block_actions","user":{"id":"AB123DEFG","username":"test.user","name":"test.user"},' \
               '"message":{"bot_id":"B011ZBY8UJ1",' \
               '"type":"message","text":"This content can\\u2019t be displayed.","user":"U011L1K39JT",' \
@@ -120,9 +120,9 @@ describe 'Sinatra App' do
               '"action_ts":"1637072709.069557"}]}' }
         end
 
-        it 'a post to replace the text is made' do
+        it "a post to replace the text is made" do
           expect_any_instance_of(SendSlackMessage).to_not receive(:upload_file)
-          post '/interactive', submitted_data
+          post "/interactive", submitted_data
           expect(a_request(:post, %r{\Ahttps://hooks.slack.com/actions/.*\z})).to have_been_made.times(1)
         end
       end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Bot do
   subject { SlackApplybot::Bot.instance }
 
-  it_behaves_like 'a slack ruby bot'
+  it_behaves_like "a slack ruby bot"
 end

--- a/spec/commands/add_user_spec.rb
+++ b/spec/commands/add_user_spec.rb
@@ -1,19 +1,19 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::AddUser, :vcr do
   let(:user_input) { "#{SlackRubyBot.config.user} #{command} #{user_csv}" }
-  let(:user_csv) { 'test.user' }
+  let(:user_csv) { "test.user" }
 
-  context 'when command is `add user`' do
+  context "when command is `add user`" do
     before do
       class_double(Portal::UserRequester).as_stubbed_const
       class_double(Portal::NameValidator, call: true).as_stubbed_const
     end
-    let(:command) { 'add user' }
+    let(:command) { "add user" }
 
-    it 'calls the user requester and sends a `typing` message to the channel' do
+    it "calls the user requester and sends a `typing` message to the channel" do
       expect(Portal::UserRequester).to receive(:initiate)
-      expect(message: user_input, channel: 'channel').to start_typing(channel: 'channel')
+      expect(message: user_input, channel: "channel").to start_typing(channel: "channel")
     end
   end
 end

--- a/spec/commands/ages_spec.rb
+++ b/spec/commands/ages_spec.rb
@@ -1,13 +1,13 @@
-require 'spec_helper'
-require 'support/commit'
+require "spec_helper"
+require "support/commit"
 describe SlackApplybot::Commands::Ages, :vcr do
   let(:user_input) { "#{SlackRubyBot.config.user} ages" }
-  let(:expected_data) { { channel: { name: 'test' } } }
+  let(:expected_data) { { channel: { name: "test" } } }
   before do
     stub_request(:post, %r{\Ahttps://slack.com/api/conversations.info\z}).to_return(status: 200, body: expected_body)
     stub_request(:any, %r{\Ahttps://(www|api).github.com/.*\z}).to_return(status: 200, body: commits, headers: {})
     allow(Github::Status).to receive(:passed?).and_return(false)
-    allow(Github::Status).to receive(:passed?).with('678912').and_return(true)
+    allow(Github::Status).to receive(:passed?).with("678912").and_return(true)
   end
   load_shared_commit_data
   let(:expected_body) do
@@ -19,7 +19,7 @@ describe SlackApplybot::Commands::Ages, :vcr do
     }.to_json
   end
 
-  context 'when the values are all valid' do
+  context "when the values are all valid" do
     let(:expected_response) do
       "Apply was deployed yesterday\n:nope: Merge pull request #1999 from moj/AA-1234\n" \
         ":nope: Merge pull request #1998 from moj/AA-421\n:yep: Merge pull request #1997 from moj/AA-666\n" \
@@ -28,14 +28,14 @@ describe SlackApplybot::Commands::Ages, :vcr do
         ":nope: Merge pull request #1998 from moj/AA-421\n:yep: Merge pull request #1997 from moj/AA-666\n" \
         ":yep: Merge pull request #1996 from moj/AA-555\n:yep: Merge pull request #1995 from moj/AA-444"
     end
-    let(:channel) { 'channel' }
+    let(:channel) { "channel" }
 
-    it 'returns the expected message' do
+    it "returns the expected message" do
       Timecop.travel(Date.new(2020, 4, 16)) do
         expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
       end
     end
 
-    it_behaves_like 'the channel is invalid'
+    it_behaves_like "the channel is invalid"
   end
 end

--- a/spec/commands/deploy_reminder_spec.rb
+++ b/spec/commands/deploy_reminder_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::DeployReminder do
   before do
@@ -8,37 +8,37 @@ describe SlackApplybot::Commands::DeployReminder do
     {
       'ok': true,
       'channel': {
-        name: 'channel'
+        name: "channel"
       }
     }.to_json
   end
   let(:user_input) do
     [
       {
-        'fallback': 'gh-user has a pending CFE production approval for master' \
-                    ' - <https://circleci.com/workflow-run/12345>',
-        'text': 'gh-user has a pending CFE production approval for master ',
+        'fallback': "gh-user has a pending CFE production approval for master" \
+                    " - <https://circleci.com/workflow-run/12345>",
+        'text': "gh-user has a pending CFE production approval for master ",
         'id': 1,
-        'color': '3AA3E3',
+        'color': "3AA3E3",
         'fields': [
           {
-            'title': 'Project',
-            'value': 'check-financial-eligibility',
+            'title': "Project",
+            'value': "check-financial-eligibility",
             'short': true
           },
           {
-            'title': 'Job Number',
-            'value': '5009',
+            'title': "Job Number",
+            'value': "5009",
             'short': true
           }
         ],
         'actions': [
           {
-            'id': '1',
-            'text': 'Visit Workflow',
-            'type': 'button',
-            'style': '',
-            'url': 'https://circleci.com/workflow-run/1234'
+            'id': "1",
+            'text': "Visit Workflow",
+            'type': "button",
+            'style': "",
+            'url': "https://circleci.com/workflow-run/1234"
           }
         ]
       }
@@ -47,9 +47,9 @@ describe SlackApplybot::Commands::DeployReminder do
 
   let!(:client) { SlackRubyBot::Client.new }
   let!(:message_command) { SlackRubyBot::Hooks::Message.new }
-  let(:params) { Hashie::Mash.new(text: 'hello', attachments: user_input, channel: 'channel', user: 'user') }
+  let(:params) { Hashie::Mash.new(text: "hello", attachments: user_input, channel: "channel", user: "user") }
 
-  it 'logs data for analysis' do
+  it "logs data for analysis" do
     expect(SlackRubyBot::Client.logger).to receive(:warn).once # .with(expected_error)
     message_command.call(client, params)
   end

--- a/spec/commands/details_spec.rb
+++ b/spec/commands/details_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::Details, :vcr do
   let(:user_input) { "#{SlackRubyBot.config.user} #{app} details #{env}" }
@@ -13,42 +13,42 @@ describe SlackApplybot::Commands::Details, :vcr do
       }
     }.to_json
   end
-  let(:app) { 'cfe' }
-  let(:env) { 'staging' }
-  let(:channel) { 'channel' }
+  let(:app) { "cfe" }
+  let(:env) { "staging" }
+  let(:channel) { "channel" }
 
-  context 'when user requests details for a valid application and environment' do
+  context "when user requests details for a valid application and environment" do
     let(:expected_response) do
-      key = '`staging` details for `cfe`'
-      build = 'app-bf400232676802bfcd7e53ff7ff013087ee6d1d1'
+      key = "`staging` details for `cfe`"
+      build = "app-bf400232676802bfcd7e53ff7ff013087ee6d1d1"
       value = "{\"build_date\"=>\"2020-04-15T15:31:45+0000\", \"build_tag\"=>\"#{build}\", \"app_branch\"=>\"master\"}"
       "#{key}:```#{value}```"
     end
 
-    it 'returns the expected message' do
-      expect(message: user_input, channel: 'channel').to respond_with_slack_message(expected_response)
+    it "returns the expected message" do
+      expect(message: user_input, channel: "channel").to respond_with_slack_message(expected_response)
     end
 
-    context 'in non-lower case' do
-      let(:app) { 'Cfe' }
+    context "in non-lower case" do
+      let(:app) { "Cfe" }
 
-      it 'returns the expected message' do
-        expect(message: user_input, channel: 'channel').to respond_with_slack_message(expected_response)
+      it "returns the expected message" do
+        expect(message: user_input, channel: "channel").to respond_with_slack_message(expected_response)
       end
     end
   end
 
-  context 'when user requests valid environment details for an invalid application' do
-    let(:app) { 'simon' }
-    let(:env) { 'staging' }
-    let(:channel) { 'channel' }
+  context "when user requests valid environment details for an invalid application" do
+    let(:app) { "simon" }
+    let(:env) { "staging" }
+    let(:channel) { "channel" }
 
     let(:expected_response) { "Sorry <@user>, I don't understand that command!" }
 
-    it 'returns the expected message' do
-      expect(message: user_input, channel: 'channel').to respond_with_slack_message(expected_response)
+    it "returns the expected message" do
+      expect(message: user_input, channel: "channel").to respond_with_slack_message(expected_response)
     end
   end
 
-  it_behaves_like 'the channel is invalid'
+  it_behaves_like "the channel is invalid"
 end

--- a/spec/commands/github_spec.rb
+++ b/spec/commands/github_spec.rb
@@ -1,14 +1,14 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::Github, :vcr do
   before do
     stub_request(:post, %r{\Ahttps://slack.com/api/conversations.info\z}).to_return(status: 200, body: expected_body)
     allow(::Github::TeamMembership).to receive(:member?).and_return(false)
-    allow(::Github::TeamMembership).to receive(:member?).with('good_user', 'laa-apply-for-legal-aid').and_return(member)
+    allow(::Github::TeamMembership).to receive(:member?).with("good_user", "laa-apply-for-legal-aid").and_return(member)
   end
 
   let(:user_input) { "#{SlackRubyBot.config.user} github #{command} #{github_id}" }
-  let(:command) { '' }
+  let(:command) { "" }
   let(:github_id) { nil }
   let(:member) { true }
   let(:expected_body) do
@@ -21,64 +21,64 @@ describe SlackApplybot::Commands::Github, :vcr do
   end
   let!(:client) { SlackRubyBot::App.new.send(:client) }
   let(:message_hook) { SlackRubyBot::Hooks::Message.new }
-  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
+  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: "user") }
   let(:expected_hash) { { channel: channel, text: expected_message } }
 
-  it_behaves_like 'the channel is invalid'
+  it_behaves_like "the channel is invalid"
 
-  context 'when the channel is valid' do
-    let(:channel) { 'channel' }
+  context "when the channel is valid" do
+    let(:channel) { "channel" }
 
-    context 'when the command is missing' do
-      let(:expected_message) { SlackRubyBot::Commands::Support::Help.instance.command_full_desc('github') }
+    context "when the command is missing" do
+      let(:expected_message) { SlackRubyBot::Commands::Support::Help.instance.command_full_desc("github") }
 
-      it 'returns the expected message' do
+      it "returns the expected message" do
         expect(client).to receive(:typing)
         expect(client).to receive(:say).with(expected_hash)
         message_hook.call(client, params)
       end
     end
 
-    context 'when the command is unsupported' do
-      let(:command) { 'delete' }
-      let(:expected_message) { 'You called `github` with `delete`. This is not supported.' }
+    context "when the command is unsupported" do
+      let(:command) { "delete" }
+      let(:expected_message) { "You called `github` with `delete`. This is not supported." }
 
-      it 'returns the expected message' do
+      it "returns the expected message" do
         expect(client).to receive(:typing)
         expect(client).to receive(:say).with(expected_hash)
         message_hook.call(client, params)
       end
     end
 
-    context 'when the command is correct' do
-      let(:command) { 'link' }
+    context "when the command is correct" do
+      let(:command) { "link" }
 
-      context 'when a no github ID is provided' do
-        let(:expected_message) { 'Github ID not provided, please call as `github link <github_user_name>`' }
+      context "when a no github ID is provided" do
+        let(:expected_message) { "Github ID not provided, please call as `github link <github_user_name>`" }
 
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(client).to receive(:typing)
           expect(client).to receive(:say).with(expected_hash)
           message_hook.call(client, params)
         end
       end
 
-      context 'when a valid github ID is provided' do
-        let(:github_id) { 'good_user' }
-        let(:expected_message) { 'Github link successfully configured' }
+      context "when a valid github ID is provided" do
+        let(:github_id) { "good_user" }
+        let(:expected_message) { "Github link successfully configured" }
 
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(client).to receive(:typing)
           expect(client).to receive(:say).with(expected_hash)
           message_hook.call(client, params)
         end
       end
 
-      context 'when an invalid github ID is provided' do
-        let(:github_id) { 'bad_user' }
-        let(:expected_message) { 'This github user is not in the correct team, please request access' }
+      context "when an invalid github ID is provided" do
+        let(:github_id) { "bad_user" }
+        let(:expected_message) { "This github user is not in the correct team, please request access" }
 
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(client).to receive(:typing)
           expect(client).to receive(:say).with(expected_hash)
           message_hook.call(client, params)

--- a/spec/commands/helm_spec.rb
+++ b/spec/commands/helm_spec.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::Helm, :vcr do
   before do
     stub_request(:post, %r{\Ahttps://slack.com/api/conversations.info\z}).to_return(status: 200, body: expected_body)
-    allow(Helm::List).to receive(:call).with('hmrc').and_return("ap3456\nap4567")
-    allow(Helm::List).to receive(:call).with('apply').and_return("ap1234\nap2345")
-    allow(Helm::Tidy).to receive(:call).with('hmrc').and_return(tidy_hmrc_return)
-    allow(Helm::Tidy).to receive(:call).with('apply').and_return(tidy_return)
+    allow(Helm::List).to receive(:call).with("hmrc").and_return("ap3456\nap4567")
+    allow(Helm::List).to receive(:call).with("apply").and_return("ap1234\nap2345")
+    allow(Helm::Tidy).to receive(:call).with("hmrc").and_return(tidy_hmrc_return)
+    allow(Helm::Tidy).to receive(:call).with("apply").and_return(tidy_return)
   end
   let(:expected_body) do
     {
@@ -17,135 +17,135 @@ describe SlackApplybot::Commands::Helm, :vcr do
     }.to_json
   end
   let(:tidy_return) do
-    ':nope: apply-ap-2345-second-name - branch deleted - you can run the following locally  - ' \
+    ":nope: apply-ap-2345-second-name - branch deleted - you can run the following locally  - " \
       "`helm delete apply-ap-2345-second-name --dry-run`\n" \
-      '1 branch retained'
+      "1 branch retained"
   end
   let(:tidy_hmrc_return) do
-    ':nope: ap-2345-second-name - branch deleted - you can run the following locally  - ' \
+    ":nope: ap-2345-second-name - branch deleted - you can run the following locally  - " \
       "`helm delete ap-2345-second-name --dry-run`\n" \
-      '1 branch retained'
+      "1 branch retained"
   end
   let(:user_input) { "#{SlackRubyBot.config.user} helm #{command}" }
-  let(:command) { '' }
+  let(:command) { "" }
 
-  it_behaves_like 'the channel is invalid'
-  context 'when the channel is valid' do
-    let(:channel) { 'channel' }
+  it_behaves_like "the channel is invalid"
+  context "when the channel is valid" do
+    let(:channel) { "channel" }
 
-    context 'when the command is missing' do
-      let(:missing_command_response) { SlackRubyBot::Commands::Support::Help.instance.command_full_desc('helm') }
-      it 'returns the expected message' do
+    context "when the command is missing" do
+      let(:missing_command_response) { SlackRubyBot::Commands::Support::Help.instance.command_full_desc("helm") }
+      it "returns the expected message" do
         expect(message: user_input, channel: channel).to respond_with_slack_message(missing_command_response)
       end
     end
 
-    context 'when the command is unsupported' do
-      let(:command) { 'destroy' }
-      let(:unsupported_command_response) { 'You called `helm` with `destroy`. This is not supported.' }
-      it 'returns the expected message' do
+    context "when the command is unsupported" do
+      let(:command) { "destroy" }
+      let(:unsupported_command_response) { "You called `helm` with `destroy`. This is not supported." }
+      it "returns the expected message" do
         expect(message: user_input, channel: channel).to respond_with_slack_message(unsupported_command_response)
       end
     end
 
-    context 'when the command is list' do
-      let(:command) { 'list' }
+    context "when the command is list" do
+      let(:command) { "list" }
       let(:command_response) { "ap1234\nap2345" }
-      it 'returns the expected message' do
+      it "returns the expected message" do
         expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
       end
 
-      context 'and has a context listed' do
-        let(:command) { 'list hmrc' }
+      context "and has a context listed" do
+        let(:command) { "list hmrc" }
         let(:command_response) { "ap3456\nap4567" }
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
         end
       end
 
-      context 'and has an invalid context listed' do
-        let(:command) { 'list portal' }
-        let(:command_response) { '`portal` is not a valid context, you can only use `apply, cfe, hmrc, and lfa`' }
-        it 'returns the expected message' do
+      context "and has an invalid context listed" do
+        let(:command) { "list portal" }
+        let(:command_response) { "`portal` is not a valid context, you can only use `apply, cfe, hmrc, and lfa`" }
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
         end
       end
     end
 
-    context 'when the command is tidy' do
-      let(:command) { 'tidy' }
+    context "when the command is tidy" do
+      let(:command) { "tidy" }
 
-      it 'returns the expected message' do
+      it "returns the expected message" do
         expect(message: user_input, channel: channel).to respond_with_slack_message(tidy_return)
       end
 
-      context 'and has a context listed' do
-        let(:command) { 'tidy hmrc' }
+      context "and has a context listed" do
+        let(:command) { "tidy hmrc" }
         let(:command_response) { "ap3456\nap4567" }
 
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(tidy_hmrc_return)
         end
       end
 
-      context 'and has an invalid context listed' do
-        let(:command) { 'tidy portal' }
-        let(:command_response) { '`portal` is not a valid context, you can only use `apply, cfe, hmrc, and lfa`' }
-        it 'returns the expected message' do
+      context "and has an invalid context listed" do
+        let(:command) { "tidy portal" }
+        let(:command_response) { "`portal` is not a valid context, you can only use `apply, cfe, hmrc, and lfa`" }
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
         end
       end
     end
 
-    context 'when the command is delete' do
-      context 'but no release or OTP is provided' do
-        let(:command) { 'delete' }
+    context "when the command is delete" do
+      context "but no release or OTP is provided" do
+        let(:command) { "delete" }
         let(:command_response) do
-          'Unable to delete - insufficient data, please call as `helm delete name-of-release 000000`'
+          "Unable to delete - insufficient data, please call as `helm delete name-of-release 000000`"
         end
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
         end
       end
 
-      context 'and no OTP is provided' do
-        let(:command) { 'delete ap1234' }
-        let(:command_response) { 'OTP password not provided, please call as `helm delete name-of-release 000000`' }
-        it 'returns the expected message' do
+      context "and no OTP is provided" do
+        let(:command) { "delete ap1234" }
+        let(:command_response) { "OTP password not provided, please call as `helm delete name-of-release 000000`" }
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
         end
       end
 
-      context 'and no OTP is provided' do
-        let(:command) { 'delete ap1234' }
-        let(:command_response) { 'OTP password not provided, please call as `helm delete name-of-release 000000`' }
-        it 'returns the expected message' do
+      context "and no OTP is provided" do
+        let(:command) { "delete ap1234" }
+        let(:command_response) { "OTP password not provided, please call as `helm delete name-of-release 000000`" }
+        it "returns the expected message" do
           expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
         end
       end
 
-      context 'when OTP is provided' do
+      context "when OTP is provided" do
         before do
           allow_any_instance_of(User).to receive(:encrypted_2fa_secret).and_return(encrypted_secret)
-          allow_any_instance_of(Encryption::Service).to receive(:decrypt).with(:any).and_return('123456789')
-          allow_any_instance_of(ROTP::TOTP).to receive(:verify).with('123456').and_return(valid_token?)
-          allow(::Helm::Delete).to receive(:call).with('ap1234').and_return(true)
+          allow_any_instance_of(Encryption::Service).to receive(:decrypt).with(:any).and_return("123456789")
+          allow_any_instance_of(ROTP::TOTP).to receive(:verify).with("123456").and_return(valid_token?)
+          allow(::Helm::Delete).to receive(:call).with("ap1234").and_return(true)
         end
-        let(:encrypted_secret) { Encryption::Service.encrypt('secret') }
-        let(:command) { 'delete ap1234 123456' }
+        let(:encrypted_secret) { Encryption::Service.encrypt("secret") }
+        let(:command) { "delete ap1234 123456" }
 
-        context 'and it is correct' do
-          let(:command_response) { 'ap1234 deleted' }
+        context "and it is correct" do
+          let(:command_response) { "ap1234 deleted" }
           let(:valid_token?) { true }
-          it 'returns the expected message' do
+          it "returns the expected message" do
             expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
           end
         end
 
-        context 'but it is incorrect' do
-          let(:command_response) { 'OTP password did not match, please check your authenticator app' }
+        context "but it is incorrect" do
+          let(:command_response) { "OTP password did not match, please check your authenticator app" }
           let(:valid_token?) { false }
-          it 'returns the expected message' do
+          it "returns the expected message" do
             expect(message: user_input, channel: channel).to respond_with_slack_message(command_response)
           end
         end

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackRubyBot::Commands::Help, :vcr do
   before do
@@ -12,7 +12,7 @@ describe SlackRubyBot::Commands::Help, :vcr do
       }
     }.to_json
   end
-  let(:channel) { 'channel' }
+  let(:channel) { "channel" }
   let(:user_input) { "#{SlackRubyBot.config.user} help" }
   let(:expected_response) do
     "*Weather Bot* - This bot tells you the weather.\n"\
@@ -33,24 +33,24 @@ describe SlackRubyBot::Commands::Help, :vcr do
   end
   # TODO: find out why the ruby-slack-bot is inserting thw weather bot output into the test response!
 
-  it 'returns the expected message' do
+  it "returns the expected message" do
     expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
   end
 
-  context 'when passed an explicit command' do
+  context "when passed an explicit command" do
     let(:user_input) { "#{SlackRubyBot.config.user} help details" }
     let(:expected_response) do
       "*details* - `@apply-bot <application> details <environment>` e.g. `@apply-bot cfe details staging`\n"\
         "\nShows the ping details page for the selected application and non-uat environments, "\
-        'e.g.  `@apply-bot apply details staging` or `@apply-bot cfe details production`'
+        "e.g.  `@apply-bot apply details staging` or `@apply-bot cfe details production`"
     end
 
-    it 'returns the expected message' do
+    it "returns the expected message" do
       expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
     end
   end
 
-  context 'when in a public channel' do
+  context "when in a public channel" do
     let(:expected_response) do
       <<~ADDUSER.chomp
         *add users* - `@apply-bot add users <comma separated names>`
@@ -59,8 +59,8 @@ describe SlackRubyBot::Commands::Help, :vcr do
         e.g. `@applybot add user BENREID` or `@applybot add users benreid, NEETADESOR`
       ADDUSER
     end
-    let(:channel) { 'shared_channel' }
-    it 'returns the expected message' do
+    let(:channel) { "shared_channel" }
+    it "returns the expected message" do
       expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
     end
   end

--- a/spec/commands/integration_tests_spec.rb
+++ b/spec/commands/integration_tests_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::IntegrationTests, :vcr do
   let(:user_input) { "#{SlackRubyBot.config.user} run tests" }
@@ -13,18 +13,18 @@ describe SlackApplybot::Commands::IntegrationTests, :vcr do
       }
     }.to_json
   end
-  let(:channel) { 'channel' }
+  let(:channel) { "channel" }
 
-  context 'when user requests a test run' do
-    it 'starts typing and triggers the sidekiq job' do
+  context "when user requests a test run" do
+    it "starts typing and triggers the sidekiq job" do
       expect(Worker::TestRunStart).to receive(:perform_async)
-      expect(message: user_input, channel: 'channel').to start_typing(channel: 'channel')
+      expect(message: user_input, channel: "channel").to start_typing(channel: "channel")
     end
 
-    it 'returns the expected message' do
+    it "returns the expected message" do
       expect(message: user_input, channel: channel).to be_a Hash
     end
   end
 
-  it_behaves_like 'the channel is invalid'
+  it_behaves_like "the channel is invalid"
 end

--- a/spec/commands/two_factor_auth_spec.rb
+++ b/spec/commands/two_factor_auth_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
   before do
@@ -18,13 +18,13 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
     {
       'ok': true,
       'channel': {
-        id: 'A0000B1CDEF'
+        id: "A0000B1CDEF"
       }
     }.to_json
   end
-  let(:channel) { 'channel' }
+  let(:channel) { "channel" }
   let(:is_direct_message?) { false }
-  let(:command) { 'setup' }
+  let(:command) { "setup" }
   let(:user_input) { "#{SlackRubyBot.config.user} 2fa #{command}" }
   let(:expected_hash) do
     {
@@ -34,30 +34,30 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
   end
   let!(:client) { SlackRubyBot::App.new.send(:client) }
   let(:message_hook) { SlackRubyBot::Hooks::Message.new }
-  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
+  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: "user") }
 
-  describe '#setup' do
-    let(:command) { 'setup' }
+  describe "#setup" do
+    let(:command) { "setup" }
 
-    context 'the user is in a direct message channel' do
+    context "the user is in a direct message channel" do
       let(:is_direct_message?) { true }
 
-      context 'when the user has not connected github' do
+      context "when the user has not connected github" do
         let(:dm_hash) do
-          { channel: 'A0000B1CDEF', text: 'You need to link your github account before you can setup 2FA' }
+          { channel: "A0000B1CDEF", text: "You need to link your github account before you can setup 2FA" }
         end
 
-        it 'starts typing, sends a DM and then replies in the public channel' do
+        it "starts typing, sends a DM and then replies in the public channel" do
           expect(client).to receive(:typing)
           expect(client).to receive(:say).with(dm_hash)
           message_hook.call(client, params)
         end
       end
 
-      context 'when the user has connected github' do
-        before { allow_any_instance_of(User).to receive(:github_id).and_return('123456') }
+      context "when the user has connected github" do
+        before { allow_any_instance_of(User).to receive(:github_id).and_return("123456") }
 
-        it 'starts typing, sends a DM and then replies in the public channel' do
+        it "starts typing, sends a DM and then replies in the public channel" do
           expect(client).to receive(:typing)
           expect_any_instance_of(SendSlackMessage).to receive(:upload_file)
           message_hook.call(client, params)
@@ -65,13 +65,13 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
       end
     end
 
-    context 'the user is in a public, valid channel' do
+    context "the user is in a public, valid channel" do
       let(:expected_message) { "I've sent you a DM, we probably shouldn't be talking about this in public!" }
       let(:dm_hash) do
-        { channel: 'A0000B1CDEF', text: 'You need to link your github account before you can setup 2FA' }
+        { channel: "A0000B1CDEF", text: "You need to link your github account before you can setup 2FA" }
       end
 
-      it 'responds with a warning message' do
+      it "responds with a warning message" do
         expect(client).to receive(:typing)
         expect(client).to receive(:say).with(expected_hash)
         expect(client).to receive(:say).with(dm_hash)
@@ -80,51 +80,51 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
     end
   end
 
-  describe '#confirm' do
+  describe "#confirm" do
     let(:user_input) { "#{SlackRubyBot.config.user} 2fa #{command} #{otp_code}" }
-    let(:command) { 'confirm' }
-    context 'when the message is a DM to the bot' do
-      let(:channel) { 'A0000B1CDEF' }
+    let(:command) { "confirm" }
+    context "when the message is a DM to the bot" do
+      let(:channel) { "A0000B1CDEF" }
       let(:is_direct_message?) { true }
 
-      context 'but no OTP is provided' do
-        let(:otp_code) { '' }
+      context "but no OTP is provided" do
+        let(:otp_code) { "" }
         let(:expected_message) do
-          'OTP password not provided, please call as `2fa confirm 000000`'
+          "OTP password not provided, please call as `2fa confirm 000000`"
         end
 
-        it 'returns the expected message' do
+        it "returns the expected message" do
           expect(client).to receive(:typing)
           expect(client).to receive(:say).with(expected_hash)
           message_hook.call(client, params)
         end
       end
 
-      context 'when OTP is provided' do
+      context "when OTP is provided" do
         before do
           allow_any_instance_of(User).to receive(:encrypted_2fa_secret).and_return(encrypted_secret)
-          allow_any_instance_of(Encryption::Service).to receive(:decrypt).with(:any).and_return('123456789')
-          allow_any_instance_of(ROTP::TOTP).to receive(:verify).with('123456').and_return(valid_token?)
+          allow_any_instance_of(Encryption::Service).to receive(:decrypt).with(:any).and_return("123456789")
+          allow_any_instance_of(ROTP::TOTP).to receive(:verify).with("123456").and_return(valid_token?)
         end
-        let(:encrypted_secret) { Encryption::Service.encrypt('secret') }
-        let(:otp_code) { '123456' }
+        let(:encrypted_secret) { Encryption::Service.encrypt("secret") }
+        let(:otp_code) { "123456" }
 
-        context 'and it is correct' do
-          let(:expected_message) { 'OTP has been successfully configured' }
+        context "and it is correct" do
+          let(:expected_message) { "OTP has been successfully configured" }
           let(:valid_token?) { true }
 
-          it 'returns the expected message' do
+          it "returns the expected message" do
             expect(client).to receive(:typing)
             expect(client).to receive(:say).with(expected_hash)
             message_hook.call(client, params)
           end
         end
 
-        context 'but it is incorrect' do
-          let(:expected_message) { 'OTP password did not match, please check your authenticator app' }
+        context "but it is incorrect" do
+          let(:expected_message) { "OTP password did not match, please check your authenticator app" }
           let(:valid_token?) { false }
 
-          it 'returns the expected message' do
+          it "returns the expected message" do
             expect(client).to receive(:typing)
             expect(client).to receive(:say).with(expected_hash)
             message_hook.call(client, params)
@@ -133,13 +133,13 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
       end
     end
 
-    context 'when the message is in a public, allowed channel' do
+    context "when the message is in a public, allowed channel" do
       let(:expected_message) { "I've sent you a DM, we probably shouldn't be talking about this in public!" }
-      let(:otp_code) { '' }
+      let(:otp_code) { "" }
       let(:dm_hash) do
-        { channel: 'A0000B1CDEF', text: 'OTP password not provided, please call as `2fa confirm 000000`' }
+        { channel: "A0000B1CDEF", text: "OTP password not provided, please call as `2fa confirm 000000`" }
       end
-      it 'starts typing, sends a DM and then replies in the public channel' do
+      it "starts typing, sends a DM and then replies in the public channel" do
         expect(client).to receive(:typing)
         expect(client).to receive(:say).with(expected_hash)
         expect(client).to receive(:say).with(dm_hash)
@@ -148,15 +148,15 @@ RSpec.describe SlackApplybot::Commands::TwoFactorAuth do
     end
   end
 
-  context 'when the command is unsupported' do
-    let(:command) { 'cancel' }
-    let(:expected_message) { 'You called `2fa` with `cancel`. This is not supported.' }
-    it 'returns the expected message' do
+  context "when the command is unsupported" do
+    let(:command) { "cancel" }
+    let(:expected_message) { "You called `2fa` with `cancel`. This is not supported." }
+    it "returns the expected message" do
       expect(client).to receive(:typing)
       expect(client).to receive(:say).with(expected_hash)
       message_hook.call(client, params)
     end
   end
 
-  it_behaves_like 'the channel is invalid'
+  it_behaves_like "the channel is invalid"
 end

--- a/spec/commands/uat_url_spec.rb
+++ b/spec/commands/uat_url_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe SlackApplybot::Commands::UatUrl, :vcr do
   before do
@@ -16,60 +16,60 @@ describe SlackApplybot::Commands::UatUrl, :vcr do
     }.to_json
   end
 
-  context 'when the command is unsupported' do
+  context "when the command is unsupported" do
     let(:user_input) { "#{SlackRubyBot.config.user} uat delete" }
-    let(:channel) { 'channel' }
-    let(:expected_response) { 'You called `uat` with `delete`. This is not supported.' }
+    let(:channel) { "channel" }
+    let(:expected_response) { "You called `uat` with `delete`. This is not supported." }
 
-    it 'returns the expected message' do
+    it "returns the expected message" do
       expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
     end
   end
 
-  context 'when user requests all uat urls' do
+  context "when user requests all uat urls" do
     let(:user_input) { "#{SlackRubyBot.config.user} uat urls" }
     let(:expected_response) do
       "Apply UAT urls:\n"\
         "<https://ap-1234-test.fake.service.uk|ap-1234-test>\n"\
-        '<https://ap-4321-bad.fake.service.uk|ap-4321-bad>'
+        "<https://ap-4321-bad.fake.service.uk|ap-4321-bad>"
     end
-    let(:channel) { 'channel' }
+    let(:channel) { "channel" }
 
-    it 'returns the expected message' do
+    it "returns the expected message" do
       expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
     end
 
-    it_behaves_like 'the channel is invalid'
+    it_behaves_like "the channel is invalid"
   end
 
-  context 'when user requests a specific branch' do
+  context "when user requests a specific branch" do
     let(:user_input) { "#{SlackRubyBot.config.user} uat url #{branch}" }
-    let(:channel) { 'channel' }
-    let(:branch) { 'ap-1234' }
+    let(:channel) { "channel" }
+    let(:branch) { "ap-1234" }
 
-    context 'that exists' do
+    context "that exists" do
       let(:expected_response) do
-        'Branch <https://ap-1234-test.fake.service.uk|ap-1234> is available'
+        "Branch <https://ap-1234-test.fake.service.uk|ap-1234> is available"
       end
 
-      it 'returns the expected message' do
+      it "returns the expected message" do
         expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
       end
     end
 
-    context 'that does not exist' do
-      let(:branch) { 'ap-666' }
+    context "that does not exist" do
+      let(:branch) { "ap-666" }
       let(:expected_response) do
         "Sorry I can't find a branch for #{branch} I only have:\n"\
           "<https://ap-1234-test.fake.service.uk|ap-1234-test>\n"\
-          '<https://ap-4321-bad.fake.service.uk|ap-4321-bad>'
+          "<https://ap-4321-bad.fake.service.uk|ap-4321-bad>"
       end
 
-      it 'returns the expected message' do
+      it "returns the expected message" do
         expect(message: user_input, channel: channel).to respond_with_slack_message(expected_response)
       end
     end
 
-    it_behaves_like 'the channel is invalid'
+    it_behaves_like "the channel is invalid"
   end
 end

--- a/spec/encryption/service_spec.rb
+++ b/spec/encryption/service_spec.rb
@@ -1,23 +1,23 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Encryption::Service do
   subject(:encryption_service) { described_class }
 
-  describe '.encrypt' do
+  describe ".encrypt" do
     subject(:encrypting) { encryption_service.encrypt(value) }
 
-    let(:value) { 'plain_text' }
+    let(:value) { "plain_text" }
 
     it { is_expected.to_not eq value }
   end
 
-  describe '.decrypt' do
+  describe ".decrypt" do
     subject(:decrypting) { encryption_service.decrypt(encoded) }
 
-    let(:input) { 'plain_text' }
+    let(:input) { "plain_text" }
     let(:encoded) { described_class.encrypt(input) }
 
-    it 'can be decoded' do
+    it "can be decoded" do
       is_expected.to eq input
     end
   end

--- a/spec/kube/client_spec.rb
+++ b/spec/kube/client_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 describe Kube::Client do
   subject(:kube_client) { described_class.call }

--- a/spec/kube/ingresses_spec.rb
+++ b/spec/kube/ingresses_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 describe Kube::Ingresses do
   subject(:kube_ingresses) { described_class.new(namespace) }
@@ -9,7 +9,7 @@ describe Kube::Ingresses do
       .to_return(status: 200, body: resource_response, headers: {})
   end
 
-  let(:namespace) { 'test' }
+  let(:namespace) { "test" }
   let(:ingress_response) do
     <<~JSON.as_json
       {"kind": "APIResourceList",
@@ -58,13 +58,13 @@ describe Kube::Ingresses do
 
   it { is_expected.to be_a Kube::Ingresses }
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { kube_ingresses.call }
 
-    it { is_expected.to eq ['ap-1234.test.service.uk'] }
+    it { is_expected.to eq ["ap-1234.test.service.uk"] }
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { described_class.call(namespace) }
 
     it { is_expected.to be_an Array }

--- a/spec/lib/apply_application_spec.rb
+++ b/spec/lib/apply_application_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'date_display'
+require "spec_helper"
+require "date_display"
 
 describe ApplyApplication do
   subject(:base) { described_class.new }
@@ -8,15 +8,15 @@ describe ApplyApplication do
   it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :github_api_url }
 
-  describe '.name' do
+  describe ".name" do
     subject(:name) { base.name }
 
-    it { is_expected.to eq 'Apply' }
+    it { is_expected.to eq "Apply" }
   end
 
-  describe '.github_api_url' do
+  describe ".github_api_url" do
     subject(:github_api_url) { base.github_api_url }
 
-    it { is_expected.to eq 'https://api.github.com/repos/moj/project-app' }
+    it { is_expected.to eq "https://api.github.com/repos/moj/project-app" }
   end
 end

--- a/spec/lib/apply_instance_spec.rb
+++ b/spec/lib/apply_instance_spec.rb
@@ -1,49 +1,49 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ApplyInstance do
   subject(:application_instance) { described_class.new(level) }
-  let(:level) { 'live' }
+  let(:level) { "live" }
 
   it { is_expected.to be_a ApplyInstance }
 
-  describe 'url' do
+  describe "url" do
     subject(:url) { application_instance.url }
 
-    context 'when level is production-like' do
-      it { is_expected.to eql 'https://apply-for-legal-aid.service.justice.gov.uk' }
+    context "when level is production-like" do
+      it { is_expected.to eql "https://apply-for-legal-aid.service.justice.gov.uk" }
     end
 
-    context 'when level staging' do
-      let(:level) { 'staging' }
+    context "when level staging" do
+      let(:level) { "staging" }
 
-      it { is_expected.to eql 'https://staging.apply-for-legal-aid.service.justice.gov.uk' }
+      it { is_expected.to eql "https://staging.apply-for-legal-aid.service.justice.gov.uk" }
     end
   end
 
-  describe 'ping_url' do
+  describe "ping_url" do
     subject(:ping_url) { application_instance.ping_url }
 
-    context 'when level is production-like' do
-      it { is_expected.to eql 'https://apply-for-legal-aid.service.justice.gov.uk/ping.json' }
+    context "when level is production-like" do
+      it { is_expected.to eql "https://apply-for-legal-aid.service.justice.gov.uk/ping.json" }
     end
 
-    context 'when level staging' do
-      let(:level) { 'staging' }
+    context "when level staging" do
+      let(:level) { "staging" }
 
-      it { is_expected.to eql 'https://staging.apply-for-legal-aid.service.justice.gov.uk/ping.json' }
+      it { is_expected.to eql "https://staging.apply-for-legal-aid.service.justice.gov.uk/ping.json" }
     end
   end
 
-  describe 'ping_data', :vcr do
+  describe "ping_data", :vcr do
     subject(:ping_data) { application_instance.ping_data }
 
-    context 'when level staging' do
-      let(:level) { 'staging' }
+    context "when level staging" do
+      let(:level) { "staging" }
       let(:expected_json) do
         {
-          'build_date' => '2020-03-20T13:59:40+0000',
-          'build_tag' => 'app-ccf322d51b508fd16316d24593a44e9c887be281',
-          'app_branch' => 'master'
+          "build_date" => "2020-03-20T13:59:40+0000",
+          "build_tag" => "app-ccf322d51b508fd16316d24593a44e9c887be281",
+          "app_branch" => "master"
         }
       end
 
@@ -51,13 +51,13 @@ describe ApplyInstance do
     end
   end
 
-  describe 'name' do
+  describe "name" do
     subject(:name) { application_instance.name }
 
-    it { is_expected.to eql('production') }
+    it { is_expected.to eql("production") }
   end
 
-  describe 'when level is not provided, instantiation fails' do
+  describe "when level is not provided, instantiation fails" do
     let(:level) { nil }
 
     it { expect { application_instance }.to raise_error(ApplyServiceInstance::InvalidInstantiationError) }

--- a/spec/lib/apply_service/base_spec.rb
+++ b/spec/lib/apply_service/base_spec.rb
@@ -1,18 +1,18 @@
-require 'spec_helper'
+require "spec_helper"
 
 class MockApplication < ApplyService::Base
   def initialize
-    super('test')
+    super("test")
   end
 end
 
 describe ApplyService::Base do
-  subject(:base) { described_class.new('test') }
+  subject(:base) { described_class.new("test") }
 
   it { expect { base }.to raise_error(ApplyService::AbstractClassError) }
 
-  context 'when it is instantiated with a missing app name' do
-    it 'returns an error message' do
+  context "when it is instantiated with a missing app name" do
+    it "returns an error message" do
       expect { MockApplication.new }.to raise_error(ApplyService::InvalidApplicationError)
     end
   end

--- a/spec/lib/apply_service_instance/base_spec.rb
+++ b/spec/lib/apply_service_instance/base_spec.rb
@@ -1,20 +1,20 @@
-require 'spec_helper'
+require "spec_helper"
 
 class MockInstance < ApplyServiceInstance::Base
   def initialize(level)
-    super('cccd', level)
+    super("cccd", level)
   end
 end
 
 describe ApplyServiceInstance::Base do
   subject(:base) { described_class.new(type, level) }
-  let(:type) { 'apply' }
-  let(:level) { 'live' }
+  let(:type) { "apply" }
+  let(:level) { "live" }
 
   it { expect { base }.to raise_error(ApplyServiceInstance::AbstractClassError) }
 
-  context 'when it is instantiated with a missing app name' do
-    it 'returns an error message' do
+  context "when it is instantiated with a missing app name" do
+    it "returns an error message" do
       expect { MockInstance.new(level) }.to raise_error(ApplyServiceInstance::InvalidApplicationError)
     end
   end

--- a/spec/lib/cfe_application_spec.rb
+++ b/spec/lib/cfe_application_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'date_display'
+require "spec_helper"
+require "date_display"
 
 describe CfeApplication do
   subject(:base) { described_class.new }
@@ -8,15 +8,15 @@ describe CfeApplication do
   it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :github_api_url }
 
-  describe '.name' do
+  describe ".name" do
     subject(:name) { base.name }
 
-    it { is_expected.to eq 'CFE' }
+    it { is_expected.to eq "CFE" }
   end
 
-  describe '.github_api_url' do
+  describe ".github_api_url" do
     subject(:github_api_url) { base.github_api_url }
 
-    it { is_expected.to eq 'https://api.github.com/repos/moj/project-api' }
+    it { is_expected.to eq "https://api.github.com/repos/moj/project-api" }
   end
 end

--- a/spec/lib/cfe_instance_spec.rb
+++ b/spec/lib/cfe_instance_spec.rb
@@ -1,52 +1,52 @@
-require 'spec_helper'
+require "spec_helper"
 
-LIVE_URL = 'https://check-financial-eligibility.apps.live-1.cloud-platform.service.justice.gov.uk'.freeze
-STAGING_URL = 'https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk'.freeze
+LIVE_URL = "https://check-financial-eligibility.apps.live-1.cloud-platform.service.justice.gov.uk".freeze
+STAGING_URL = "https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk".freeze
 
 describe CfeInstance do
   subject(:application_instance) { described_class.new(level) }
-  let(:level) { 'live' }
+  let(:level) { "live" }
 
   it { is_expected.to be_a CfeInstance }
 
-  describe 'url' do
+  describe "url" do
     subject(:url) { application_instance.url }
 
-    context 'when level is production-like' do
-      it { is_expected.to eql 'https://check-financial-eligibility.apps.live-1.cloud-platform.service.justice.gov.uk' }
+    context "when level is production-like" do
+      it { is_expected.to eql "https://check-financial-eligibility.apps.live-1.cloud-platform.service.justice.gov.uk" }
     end
 
-    context 'when level staging' do
-      let(:level) { 'staging' }
+    context "when level staging" do
+      let(:level) { "staging" }
 
       it { is_expected.to eql STAGING_URL }
     end
   end
 
-  describe 'ping_url' do
+  describe "ping_url" do
     subject(:ping_url) { application_instance.ping_url }
 
-    context 'when level is production-like' do
+    context "when level is production-like" do
       it { is_expected.to eql "#{LIVE_URL}/ping.json" }
     end
 
-    context 'when level staging' do
-      let(:level) { 'staging' }
+    context "when level staging" do
+      let(:level) { "staging" }
 
       it { is_expected.to eql "#{STAGING_URL}/ping.json" }
     end
   end
 
-  describe 'ping_data', :vcr do
+  describe "ping_data", :vcr do
     subject(:ping_data) { application_instance.ping_data }
 
-    context 'when level staging' do
-      let(:level) { 'staging' }
+    context "when level staging" do
+      let(:level) { "staging" }
       let(:expected_json) do
         {
-          'build_date' => '2020-05-26T09:46:42+0100',
-          'build_tag' => 'app-a1bd774c68094caa2a7f4b3d505e826a0aa68dc7',
-          'app_branch' => 'master'
+          "build_date" => "2020-05-26T09:46:42+0100",
+          "build_tag" => "app-a1bd774c68094caa2a7f4b3d505e826a0aa68dc7",
+          "app_branch" => "master"
         }
       end
 
@@ -54,13 +54,13 @@ describe CfeInstance do
     end
   end
 
-  describe 'name' do
+  describe "name" do
     subject(:name) { application_instance.name }
 
-    it { is_expected.to eql('production') }
+    it { is_expected.to eql("production") }
   end
 
-  describe 'when level is not provided, instantiation fails' do
+  describe "when level is not provided, instantiation fails" do
     let(:level) { nil }
 
     it { expect { application_instance }.to raise_error(ApplyServiceInstance::InvalidInstantiationError) }

--- a/spec/lib/date_display_spec.rb
+++ b/spec/lib/date_display_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'date_display'
+require "spec_helper"
+require "date_display"
 
 describe DateDisplay do
   subject(:date_display) { described_class.new(date) }
@@ -8,29 +8,29 @@ describe DateDisplay do
 
   it { is_expected.to be_a DateDisplay }
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { date_display.call }
 
-    context 'when passed today' do
-      it { is_expected.to eq 'today' }
+    context "when passed today" do
+      it { is_expected.to eq "today" }
     end
 
-    context 'when passed yesterday ' do
+    context "when passed yesterday " do
       let(:date) { Date.yesterday }
 
-      it { is_expected.to eq 'yesterday' }
+      it { is_expected.to eq "yesterday" }
     end
 
-    context 'when passed the day before yesterday ' do
+    context "when passed the day before yesterday " do
       let(:date) { Date.today - 2.days }
 
-      it { is_expected.to eq '2 days ago' }
+      it { is_expected.to eq "2 days ago" }
     end
   end
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { described_class.call(date) }
 
-    it { is_expected.to eq 'today' }
+    it { is_expected.to eq "today" }
   end
 end

--- a/spec/lib/github/branches_spec.rb
+++ b/spec/lib/github/branches_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Github::Branches do
   subject(:pull_requests) { described_class.new(application) }
@@ -11,18 +11,18 @@ RSpec.describe Github::Branches do
 
   let(:truncated_data) do
     [
-      { 'name' => 'ap-1234' },
-      { 'name' => 'ap-5432' }
+      { "name" => "ap-1234" },
+      { "name" => "ap-5432" }
     ]
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { described_class.call(application) }
 
     it { is_expected.to eq truncated_data }
   end
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { pull_requests.call }
 
     it { is_expected.to eq truncated_data }

--- a/spec/lib/github/commits_spec.rb
+++ b/spec/lib/github/commits_spec.rb
@@ -1,5 +1,5 @@
-require 'rspec'
-require 'support/commit'
+require "rspec"
+require "support/commit"
 
 RSpec.describe Github::Commits do
   subject(:github_commits) { described_class.new(application) }
@@ -7,7 +7,7 @@ RSpec.describe Github::Commits do
     stub_request(:any, %r{\Ahttps://(www|api).github.com/.*\z}).to_return(status: 200, body: commits, headers: {})
     # pass = 678912
     allow(Github::Status).to receive(:passed?).and_return(false)
-    allow(Github::Status).to receive(:passed?).with('678912').and_return(true)
+    allow(Github::Status).to receive(:passed?).with("678912").and_return(true)
   end
   let(:application) { ApplyApplication.new }
   load_shared_commit_data
@@ -21,13 +21,13 @@ RSpec.describe Github::Commits do
     RESPONSE
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { described_class.call(application) }
 
     it { is_expected.to eq expected_response }
   end
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { github_commits.call }
 
     it { is_expected.to eq expected_response }

--- a/spec/lib/github/pull_requests_spec.rb
+++ b/spec/lib/github/pull_requests_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Github::PullRequests do
   subject(:pull_requests) { described_class.new(application) }
@@ -11,18 +11,18 @@ RSpec.describe Github::PullRequests do
 
   let(:truncated_data) do
     [
-      { 'head' => { 'ref' => 'ap-1234' } },
-      { 'head' => { 'ref' => 'ap-5432' } }
+      { "head" => { "ref" => "ap-1234" } },
+      { "head" => { "ref" => "ap-5432" } }
     ]
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { described_class.call(application) }
 
     it { is_expected.to eq truncated_data }
   end
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { pull_requests.call }
 
     it { is_expected.to eq truncated_data }

--- a/spec/lib/github/status_spec.rb
+++ b/spec/lib/github/status_spec.rb
@@ -1,5 +1,5 @@
-require 'rspec'
-require 'support/commit'
+require "rspec"
+require "support/commit"
 
 RSpec.describe Github::Status do
   subject(:github_status) { described_class.new(url) }
@@ -7,21 +7,21 @@ RSpec.describe Github::Status do
     stub_request(:any, %r{\Ahttps://(www|api).github.com/.*/status\z})
       .to_return(status: 200, body: expected, headers: {})
   end
-  let(:url) { 'https://api.github.com/repos/moj/project/commits/123456' }
+  let(:url) { "https://api.github.com/repos/moj/project/commits/123456" }
   let(:expected) do
     {
-      'state' => 'pending'
+      "state" => "pending"
     }.to_json
   end
   load_shared_commit_data
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { github_status.call }
 
-    it { is_expected.to eq 'pending' }
+    it { is_expected.to eq "pending" }
   end
 
-  describe '.passed?' do
+  describe ".passed?" do
     subject(:passed?) { described_class.passed?(url) }
 
     it { is_expected.to be false }

--- a/spec/lib/github/team_membership_spec.rb
+++ b/spec/lib/github/team_membership_spec.rb
@@ -1,5 +1,5 @@
-require 'rspec'
-require 'support/commit'
+require "rspec"
+require "support/commit"
 
 RSpec.describe Github::TeamMembership do
   subject(:github_team_membership) { described_class.new(user, group) }
@@ -8,39 +8,39 @@ RSpec.describe Github::TeamMembership do
       .to_return(status: 200, body: expected, headers: {})
   end
 
-  let(:user) { 'good_user' }
-  let(:group) { 'test_group' }
+  let(:user) { "good_user" }
+  let(:group) { "test_group" }
   let(:expected) do
     [
       {
-        'login' => 'good_user',
-        'id' => '123456',
-        'type' => 'user'
+        "login" => "good_user",
+        "id" => "123456",
+        "type" => "user"
       },
       {
-        'login' => 'colleague',
-        'id' => '654321',
-        'type' => 'user'
+        "login" => "colleague",
+        "id" => "654321",
+        "type" => "user"
       }
 
     ].to_json
   end
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { github_team_membership.call }
 
     it { is_expected.to eq %w[good_user colleague] }
   end
 
-  describe '.member?' do
+  describe ".member?" do
     subject(:member?) { described_class.member?(user, group) }
 
-    context 'when the user is in the group' do
+    context "when the user is in the group" do
       it { is_expected.to be true }
     end
 
-    context 'when the user is not in the group' do
-      let(:user) { 'bad_user' }
+    context "when the user is not in the group" do
+      let(:user) { "bad_user" }
 
       it { is_expected.to be false }
     end

--- a/spec/lib/github_values_spec.rb
+++ b/spec/lib/github_values_spec.rb
@@ -1,14 +1,14 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GithubValues do
   subject(:base) { described_class.new }
   before { allow(ENV).to receive(:[]).and_call_original }
 
-  let(:base_url) { 'https://api.github.com/repos/moj/project' }
+  let(:base_url) { "https://api.github.com/repos/moj/project" }
 
   it { is_expected.to be_a GithubValues }
 
-  describe '#headers' do
+  describe "#headers" do
     subject(:headers) { described_class.headers }
     let(:json_keys) { %i[content_type accept Authorization] }
 
@@ -16,36 +16,36 @@ describe GithubValues do
     it { expect(subject.keys).to contain_exactly(*json_keys) }
   end
 
-  describe '#repo_url' do
+  describe "#repo_url" do
     subject(:repo_url) { described_class.repo_url }
 
     it { is_expected.to eql(base_url) }
   end
 
-  describe '#build_url' do
+  describe "#build_url" do
     subject(:build_url) { described_class.build_url(extension) }
-    let(:extension) { '/extend' }
+    let(:extension) { "/extend" }
 
-    it { is_expected.to eql('https://api.github.com/repos/moj/project/extend') }
+    it { is_expected.to eql("https://api.github.com/repos/moj/project/extend") }
   end
 
-  describe '#running_job_url' do
+  describe "#running_job_url" do
     subject(:running_job_url) { described_class.running_job_url }
 
     it { is_expected.to eql("#{base_url}/actions/workflows/manual-integration-tests.yml/runs?status=in_progress") }
   end
 
-  describe '#wait_time' do
+  describe "#wait_time" do
     subject(:wait_time) { described_class.wait_time }
 
-    context 'when a value is set' do
-      before { allow(ENV).to receive(:[]).with('GITHUB_WAIT_SECONDS').and_return(1) }
+    context "when a value is set" do
+      before { allow(ENV).to receive(:[]).with("GITHUB_WAIT_SECONDS").and_return(1) }
 
       it { is_expected.to eq 1 }
     end
 
-    context 'when an setting is not present' do
-      before { allow(ENV).to receive(:[]).with('GITHUB_WAIT_SECONDS').and_return(0) }
+    context "when an setting is not present" do
+      before { allow(ENV).to receive(:[]).with("GITHUB_WAIT_SECONDS").and_return(0) }
 
       it { is_expected.to eq 0 }
     end

--- a/spec/lib/helm/delete_spec.rb
+++ b/spec/lib/helm/delete_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Helm::Delete do
-  describe '#call' do
-    subject(:call) { described_class.call('ap1234') }
+  describe "#call" do
+    subject(:call) { described_class.call("ap1234") }
     before { allow(described_class).to receive(:`).with(/helm delete.*/).and_return(response) }
     let(:response) { 'release "ap1234" uninstalled' }
 

--- a/spec/lib/helm/list_spec.rb
+++ b/spec/lib/helm/list_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Helm::List do
-  describe '#call' do
+  describe "#call" do
     subject(:call) { described_class.call }
-    let(:github_url) { 'https://api.github.com/repos/moj/project-app' }
+    let(:github_url) { "https://api.github.com/repos/moj/project-app" }
     before do
-      allow(described_class).to receive(:`).with('helm list --kube-context apply-context -o json').and_return(raw_json)
+      allow(described_class).to receive(:`).with("helm list --kube-context apply-context -o json").and_return(raw_json)
       stub_request(:get, "#{github_url}/branches?per_page=100").to_return(status: 200,
                                                                           body: truncated_branch_data.to_json,
                                                                           headers: {})
@@ -15,44 +15,44 @@ RSpec.describe Helm::List do
     end
     let(:truncated_branch_data) do
       [
-        { 'name' => 'ap-1234-first-name' },
-        { 'name' => 'ap-5432-second-name' }
+        { "name" => "ap-1234-first-name" },
+        { "name" => "ap-5432-second-name" }
       ]
     end
     let(:truncated_pr_data) do
       [
-        { 'head' => { 'ref' => 'ap-1234-first-name' } },
-        { 'head' => { 'ref' => 'ap-5432-second-name' } }
+        { "head" => { "ref" => "ap-1234-first-name" } },
+        { "head" => { "ref" => "ap-5432-second-name" } }
       ]
     end
     let(:raw_json) do
       [
         {
-          'name' => 'apply-ap-1234-first-name',
-          'namespace' => 'my-fake-namespace',
-          'revision' => '2',
-          'updated' => '2021-02-10 14:31:22.723418433 +0000 UTC',
-          'status' => 'deployed',
-          'chart' => 'my-fake-chart-0.1.0',
-          'app_version' => '1.16.0'
+          "name" => "apply-ap-1234-first-name",
+          "namespace" => "my-fake-namespace",
+          "revision" => "2",
+          "updated" => "2021-02-10 14:31:22.723418433 +0000 UTC",
+          "status" => "deployed",
+          "chart" => "my-fake-chart-0.1.0",
+          "app_version" => "1.16.0"
         },
         {
-          'name' => 'apply-ap-2345-second-name',
-          'namespace' => 'my-fake-namespace',
-          'revision' => '1',
-          'updated' => '2021-02-10 11:52:16.566921696 +0000 UTC',
-          'status' => 'deployed',
-          'chart' => 'my-fake-chart-0.1.0',
-          'app_version' => '1.16.0'
+          "name" => "apply-ap-2345-second-name",
+          "namespace" => "my-fake-namespace",
+          "revision" => "1",
+          "updated" => "2021-02-10 11:52:16.566921696 +0000 UTC",
+          "status" => "deployed",
+          "chart" => "my-fake-chart-0.1.0",
+          "app_version" => "1.16.0"
         }
       ].to_json
     end
     let(:expected) do
-      '```'\
+      "```"\
         "Name                                    Status         Date       PR Branch \n"\
         "apply-ap-1234-first-name                deployed       2021-02-10 ✔  ✔      \n"\
-        'apply-ap-2345-second-name               deployed       2021-02-10           '\
-        '```'
+        "apply-ap-2345-second-name               deployed       2021-02-10           "\
+        "```"
     end
 
     it { expect(subject).to eql(expected) }

--- a/spec/lib/helm/tidy_spec.rb
+++ b/spec/lib/helm/tidy_spec.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Helm::Tidy do
-  describe '#call' do
+  describe "#call" do
     subject(:call) { described_class.call }
 
-    let(:github_url) { 'https://api.github.com/repos/moj/project-app' }
+    let(:github_url) { "https://api.github.com/repos/moj/project-app" }
     before do
-      allow(described_class).to receive(:`).with('helm list --kube-context apply-context -o json').and_return(raw_json)
+      allow(described_class).to receive(:`).with("helm list --kube-context apply-context -o json").and_return(raw_json)
       stub_request(:get, "#{github_url}/branches?per_page=100").to_return(status: 200,
                                                                           body: truncated_branch_data.to_json,
                                                                           headers: {})
@@ -16,42 +16,42 @@ RSpec.describe Helm::Tidy do
     end
     let(:truncated_branch_data) do
       [
-        { 'name' => 'ap-1234-first-name' },
-        { 'name' => 'ap-5432-second-name' }
+        { "name" => "ap-1234-first-name" },
+        { "name" => "ap-5432-second-name" }
       ]
     end
     let(:truncated_pr_data) do
       [
-        { 'head' => { 'ref' => 'ap-1234-first-name' } },
-        { 'head' => { 'ref' => 'ap-5432-second-name' } }
+        { "head" => { "ref" => "ap-1234-first-name" } },
+        { "head" => { "ref" => "ap-5432-second-name" } }
       ]
     end
     let(:raw_json) do
       [
         {
-          'name' => 'apply-ap-1234-first-name',
-          'namespace' => 'my-fake-namespace',
-          'revision' => '2',
-          'updated' => '2021-02-10 14:31:22.723418433 +0000 UTC',
-          'status' => 'deployed',
-          'chart' => 'my-fake-chart-0.1.0',
-          'app_version' => '1.16.0'
+          "name" => "apply-ap-1234-first-name",
+          "namespace" => "my-fake-namespace",
+          "revision" => "2",
+          "updated" => "2021-02-10 14:31:22.723418433 +0000 UTC",
+          "status" => "deployed",
+          "chart" => "my-fake-chart-0.1.0",
+          "app_version" => "1.16.0"
         },
         {
-          'name' => 'apply-ap-2345-second-name',
-          'namespace' => 'my-fake-namespace',
-          'revision' => '1',
-          'updated' => '2021-02-10 11:52:16.566921696 +0000 UTC',
-          'status' => 'deployed',
-          'chart' => 'my-fake-chart-0.1.0',
-          'app_version' => '1.16.0'
+          "name" => "apply-ap-2345-second-name",
+          "namespace" => "my-fake-namespace",
+          "revision" => "1",
+          "updated" => "2021-02-10 11:52:16.566921696 +0000 UTC",
+          "status" => "deployed",
+          "chart" => "my-fake-chart-0.1.0",
+          "app_version" => "1.16.0"
         }
       ].to_json
     end
     let(:expected) do
-      ':nope: apply-ap-2345-second-name - branch deleted - you can run the following locally  - ' \
+      ":nope: apply-ap-2345-second-name - branch deleted - you can run the following locally  - " \
         "`helm delete apply-ap-2345-second-name --dry-run`\n" \
-        '1 branch retained'
+        "1 branch retained"
     end
 
     it { expect(subject).to eql(expected) }

--- a/spec/lib/portal/generate_script_spec.rb
+++ b/spec/lib/portal/generate_script_spec.rb
@@ -1,11 +1,11 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Portal::GenerateScript do
   subject(:portal_script) { described_class.new(names) }
 
-  context 'when a valid array of Portal::Name objects is passed' do
+  context "when a valid array of Portal::Name objects is passed" do
     let(:names) { [one] }
-    let(:one) { instance_double(Portal::Name, portal_username: 'TEST%20NAME', display_name: 'TEST NAME') }
+    let(:one) { instance_double(Portal::Name, portal_username: "TEST%20NAME", display_name: "TEST NAME") }
     let(:expected_output) do
       <<~SCRIPT.chomp
         dn: cn=CCMS_Apply,cn=Groups,dc=lab,dc=gov
@@ -15,13 +15,13 @@ RSpec.describe Portal::GenerateScript do
       SCRIPT
     end
 
-    describe '.call' do
+    describe ".call" do
       subject(:call) { portal_script.call }
 
       it { is_expected.to eq expected_output }
     end
 
-    describe '#call' do
+    describe "#call" do
       subject(:call) { described_class.call(names) }
 
       it { is_expected.to eq expected_output }

--- a/spec/lib/portal/messages/failure_spec.rb
+++ b/spec/lib/portal/messages/failure_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Portal::Messages::Failure do
   subject(:failure) { described_class.call(names) }
@@ -6,30 +6,30 @@ describe Portal::Messages::Failure do
   let(:expected_response) do
     [
       {
-        'type': 'section',
+        'type': "section",
         'text': {
-          'type': 'mrkdwn',
-          'text': 'The following name(s) could not be matched in CCMS'
+          'type': "mrkdwn",
+          'text': "The following name(s) could not be matched in CCMS"
         }
       },
       {
-        'type': 'section',
+        'type': "section",
         'text': {
-          'type': 'mrkdwn',
+          'type': "mrkdwn",
           'text': "```name1\nname2```"
         }
       },
       {
-        'type': 'section',
+        'type': "section",
         'text': {
-          'type': 'mrkdwn',
-          'text': 'You will need to confirm their account names and re-submit'
+          'type': "mrkdwn",
+          'text': "You will need to confirm their account names and re-submit"
         }
       }
     ]
   end
 
-  it 'returns the expected blocks' do
+  it "returns the expected blocks" do
     expect(failure).to eq expected_response
   end
 end

--- a/spec/lib/portal/messages/success_spec.rb
+++ b/spec/lib/portal/messages/success_spec.rb
@@ -1,62 +1,62 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Portal::Messages::Success do
   subject(:success) { described_class.call(script) }
-  let(:script) { 'contents of script' }
+  let(:script) { "contents of script" }
   let(:expected_response) do
     [
       {
-        'type': 'section',
+        'type': "section",
         'text': {
-          'type': 'mrkdwn',
-          'text': 'These user names matched in CCMS'
+          'type': "mrkdwn",
+          'text': "These user names matched in CCMS"
         }
       },
       {
-        'block_id': 'user-script',
-        'type': 'section',
+        'block_id': "user-script",
+        'type': "section",
         'text': {
-          'type': 'mrkdwn',
-          'text': '```contents of script```'
+          'type': "mrkdwn",
+          'text': "```contents of script```"
         }
       },
       {
-        'type': 'section',
+        'type': "section",
         'text': {
-          'type': 'mrkdwn',
-          'text': 'Send this script to the new_user channel?'
+          'type': "mrkdwn",
+          'text': "Send this script to the new_user channel?"
         }
       },
       {
-        'block_id': 'new_user_response',
-        'type': 'actions',
+        'block_id': "new_user_response",
+        'type': "actions",
         'elements': [
           {
-            'type': 'button',
+            'type': "button",
             'text': {
-              'type': 'plain_text',
+              'type': "plain_text",
               'emoji': true,
-              'text': 'Approve'
+              'text': "Approve"
             },
-            'style': 'primary',
-            'value': 'approve'
+            'style': "primary",
+            'value': "approve"
           },
           {
-            'type': 'button',
+            'type': "button",
             'text': {
-              'type': 'plain_text',
+              'type': "plain_text",
               'emoji': true,
-              'text': 'Reject'
+              'text': "Reject"
             },
-            'style': 'danger',
-            'value': 'reject'
+            'style': "danger",
+            'value': "reject"
           }
         ]
       }
     ]
   end
 
-  it 'returns the expected blocks' do
+  it "returns the expected blocks" do
     expect(success).to eq expected_response
   end
 end

--- a/spec/lib/portal/name_error_message_spec.rb
+++ b/spec/lib/portal/name_error_message_spec.rb
@@ -1,13 +1,13 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Portal::NameErrorMessage do
   subject { described_class.call(names) }
   let(:names) { [one, two] }
-  let(:one) { instance_double(Portal::Name, display_name: 'TEST NAME', errors: 'User TEST.NAME not known to CCMS') }
-  let(:two) { instance_double(Portal::Name, display_name: 'TEST TWO', errors: nil) }
+  let(:one) { instance_double(Portal::Name, display_name: "TEST NAME", errors: "User TEST.NAME not known to CCMS") }
+  let(:two) { instance_double(Portal::Name, display_name: "TEST TWO", errors: nil) }
   before do
-    allow(Portal::Name).to receive(:new).with('test.name').and_return(one)
-    allow(Portal::Name).to receive(:new).with('test two').and_return(two)
+    allow(Portal::Name).to receive(:new).with("test.name").and_return(one)
+    allow(Portal::Name).to receive(:new).with("test two").and_return(two)
   end
 
   it { is_expected.to eq "*TEST NAME* :nope: User TEST.NAME not known to CCMS\n*TEST TWO* :yep:" }

--- a/spec/lib/portal/name_spec.rb
+++ b/spec/lib/portal/name_spec.rb
@@ -1,19 +1,19 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Portal::Name do
   subject(:portal_name) { described_class.new(name) }
 
-  let(:name) { 'test.name' }
+  let(:name) { "test.name" }
 
-  describe '#build' do
+  describe "#build" do
     subject(:build) { portal_name.build }
 
-    context 'name is text' do
+    context "name is text" do
       let(:expected_hash) do
         {
-          original_name: 'test.name',
-          display_name: 'TEST.NAME',
-          portal_username: 'TEST.NAME',
+          original_name: "test.name",
+          display_name: "TEST.NAME",
+          portal_username: "TEST.NAME",
           portal_name_valid: nil,
           errors: nil
         }
@@ -22,13 +22,13 @@ RSpec.describe Portal::Name do
       it { expect(build.as_json.symbolize_keys).to eq expected_hash }
     end
 
-    context 'name has a space' do
-      let(:name) { 'test name' }
+    context "name has a space" do
+      let(:name) { "test name" }
       let(:expected_hash) do
         {
-          original_name: 'test name',
-          display_name: 'TEST NAME',
-          portal_username: 'TEST%20NAME',
+          original_name: "test name",
+          display_name: "TEST NAME",
+          portal_username: "TEST%20NAME",
           portal_name_valid: nil,
           errors: nil
         }
@@ -37,13 +37,13 @@ RSpec.describe Portal::Name do
       it { expect(build.as_json.symbolize_keys).to eq expected_hash }
     end
 
-    context 'name is an email' do
-      let(:name) { 'test.name@example.com' }
+    context "name is an email" do
+      let(:name) { "test.name@example.com" }
       let(:expected_hash) do
         {
-          original_name: 'test.name@example.com',
-          display_name: 'TEST.NAME@EXAMPLE.COM',
-          portal_username: 'TEST.NAME@EXAMPLE.COM',
+          original_name: "test.name@example.com",
+          display_name: "TEST.NAME@EXAMPLE.COM",
+          portal_username: "TEST.NAME@EXAMPLE.COM",
           portal_name_valid: nil,
           errors: nil
         }
@@ -52,13 +52,13 @@ RSpec.describe Portal::Name do
       it { expect(build.as_json.symbolize_keys).to eq expected_hash }
     end
 
-    context 'name is a slack parsed email' do
-      let(:name) { '<MAILTO:test.name@example.com|test.name@example.com>' }
+    context "name is a slack parsed email" do
+      let(:name) { "<MAILTO:test.name@example.com|test.name@example.com>" }
       let(:expected_hash) do
         {
-          original_name: 'test.name@example.com',
-          display_name: 'TEST.NAME@EXAMPLE.COM',
-          portal_username: 'TEST.NAME@EXAMPLE.COM',
+          original_name: "test.name@example.com",
+          display_name: "TEST.NAME@EXAMPLE.COM",
+          portal_username: "TEST.NAME@EXAMPLE.COM",
           portal_name_valid: nil,
           errors: nil
         }

--- a/spec/lib/portal/name_validator_spec.rb
+++ b/spec/lib/portal/name_validator_spec.rb
@@ -1,38 +1,38 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Portal::NameValidator do
   subject(:validate) { described_class.new(user) }
 
-  context 'when instantiated without a Portal::Name object' do
-    let(:user) { 'TEST.NAME' }
+  context "when instantiated without a Portal::Name object" do
+    let(:user) { "TEST.NAME" }
 
-    it { expect { subject }.to raise_error(StandardError, 'Name is invalid type') }
+    it { expect { subject }.to raise_error(StandardError, "Name is invalid type") }
   end
 
-  context 'when instantiated without a Portal::Name object' do
+  context "when instantiated without a Portal::Name object" do
     before do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('PROVIDER_DETAILS_URL').and_return(dummy_provider_details_host)
+      allow(ENV).to receive(:[]).with("PROVIDER_DETAILS_URL").and_return(dummy_provider_details_host)
       stub_request(:get, api_url).to_return(body: response_body, status: http_status)
     end
 
-    let(:dummy_provider_details_host) { 'http://my_dummy_url/' }
+    let(:dummy_provider_details_host) { "http://my_dummy_url/" }
     let(:api_url) { "#{dummy_provider_details_host}#{user.portal_username}" }
     let(:response_body) { sarah_smith_response.to_json }
     let(:http_status) { 200 }
-    let(:user) { Portal::Name.new('test.user') }
-    describe '#call' do
+    let(:user) { Portal::Name.new("test.user") }
+    describe "#call" do
       subject(:call_validate) { validate.call }
 
       it do
         expect { call_validate }.to change { user.portal_name_valid }.to true
       end
 
-      describe 'error handling' do
-        context 'user adds non-ascii characters to their name' do
+      describe "error handling" do
+        context "user adds non-ascii characters to their name" do
           # we suspect that this comes from a cut and paste from MS into
           # the login box when parsed it returns BRAND%20NEW\u2011USER
-          let(:user) { Portal::Name.new('brand new‒user') }
+          let(:user) { Portal::Name.new("brand new‒user") }
           let(:response_body) { sarah_smith_response.to_json }
           let(:http_status) { 200 }
           let(:error_message) { "'BRAND NEW‒USER' contains unicode characters, please re-type if cut and pasted" }
@@ -41,32 +41,32 @@ RSpec.describe Portal::NameValidator do
           it { expect { call_validate }.to change { user.errors }.to error_message }
         end
 
-        context 'username not on provider details api' do
+        context "username not on provider details api" do
           let(:response_body) { user_not_found_response.to_json }
           let(:http_status) { 404 }
 
-          it 'responds false' do
+          it "responds false" do
             expect(subject).to be false
           end
 
           it { expect { call_validate }.to change { user.portal_name_valid }.to false }
-          it { expect { call_validate }.to change { user.errors }.to 'User TEST.USER not known to CCMS' }
+          it { expect { call_validate }.to change { user.errors }.to "User TEST.USER not known to CCMS" }
         end
 
-        context 'other non-200 response' do
-          let(:response_body) { '' }
+        context "other non-200 response" do
+          let(:response_body) { "" }
           let(:http_status) { 505 }
-          it 'responds false' do
+          it "responds false" do
             expect(subject).to be false
           end
         end
       end
     end
 
-    describe '.call' do
+    describe ".call" do
       subject(:call) { described_class.call(user) }
 
-      let(:user) { Portal::Name.new('test.user') }
+      let(:user) { Portal::Name.new("test.user") }
 
       it do
         expect { call }.to change { user.portal_name_valid }.to true
@@ -76,24 +76,24 @@ RSpec.describe Portal::NameValidator do
 
   def sarah_smith_response
     {
-      'providerFirmId' => 24_493,
-      'contactUserId' => 47_096,
-      'contacts' => [
-        { 'id' => 3_043_807, 'name' => 'NAME.ONE' },
-        { 'id' => 3_178_792, 'name' => 'DJXANKAZTAL' }
+      "providerFirmId" => 24_493,
+      "contactUserId" => 47_096,
+      "contacts" => [
+        { "id" => 3_043_807, "name" => "NAME.ONE" },
+        { "id" => 3_178_792, "name" => "DJXANKAZTAL" }
       ],
-      'feeEarners' => [],
-      'providerOffices' => [{ 'id' => '81333', 'name' => 'LOCAL LAW & CO LTD-8B869F' }]
+      "feeEarners" => [],
+      "providerOffices" => [{ "id" => "81333", "name" => "LOCAL LAW & CO LTD-8B869F" }]
     }
   end
 
   def user_not_found_response
     {
-      'timestamp' => '2020-07-28T10:52:01.141+0000',
-      'status' => 404,
-      'error' => 'Not Found',
-      'message' => 'No records found for [SARAH%20SMITH]',
-      'path' => '/api/providerDetails/SARAH%20SMITH'
+      "timestamp" => "2020-07-28T10:52:01.141+0000",
+      "status" => 404,
+      "error" => "Not Found",
+      "message" => "No records found for [SARAH%20SMITH]",
+      "path" => "/api/providerDetails/SARAH%20SMITH"
     }
   end
 end

--- a/spec/lib/portal/names/collator_spec.rb
+++ b/spec/lib/portal/names/collator_spec.rb
@@ -1,40 +1,40 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Portal::Names::Collator do
   subject(:collator) { described_class.new(names) }
   before do
-    allow(Portal::Name).to receive(:new).with('TEST.NAME').and_return(one)
-    allow(Portal::Name).to receive(:new).with('TEST TWO').and_return(two)
-    allow(Portal::Name).to receive(:new).with('TEST').and_return(three)
+    allow(Portal::Name).to receive(:new).with("TEST.NAME").and_return(one)
+    allow(Portal::Name).to receive(:new).with("TEST TWO").and_return(two)
+    allow(Portal::Name).to receive(:new).with("TEST").and_return(three)
     class_double(Portal::NameValidator, call: true).as_stubbed_const
   end
-  let(:names) { 'test two,test.name ,test' }
+  let(:names) { "test two,test.name ,test" }
   let(:one) do
-    instance_double(Portal::Name, display_name: 'TEST NAME',
-                                  portal_username: 'TEST NAME',
-                                  errors: 'User TEST.NAME not known to CCMS')
+    instance_double(Portal::Name, display_name: "TEST NAME",
+                                  portal_username: "TEST NAME",
+                                  errors: "User TEST.NAME not known to CCMS")
   end
-  let(:two) { instance_double(Portal::Name, display_name: 'TEST TWO', portal_username: 'TEST TWO', errors: nil) }
-  let(:three) { instance_double(Portal::Name, display_name: 'THREE', portal_username: 'THREE', errors: nil) }
+  let(:two) { instance_double(Portal::Name, display_name: "TEST TWO", portal_username: "TEST TWO", errors: nil) }
+  let(:three) { instance_double(Portal::Name, display_name: "THREE", portal_username: "THREE", errors: nil) }
 
   it { is_expected.to respond_to :matched_names }
   it { is_expected.to respond_to :unmatched_names }
 
-  describe '.matched_names' do
+  describe ".matched_names" do
     subject(:matched_names) { collator.matched_names }
 
-    it 'returns an array of name objects' do
+    it "returns an array of name objects" do
       is_expected.to be_a Array
     end
   end
 
-  describe '.unmatched_names' do
+  describe ".unmatched_names" do
     before do
       class_double(Portal::NameValidator, call: false).as_stubbed_const
     end
     subject(:unmatched_names) { collator.unmatched_names }
 
-    it 'returns an array of name objects' do
+    it "returns an array of name objects" do
       is_expected.to be_a Array
     end
   end

--- a/spec/lib/portal/output_channel_spec.rb
+++ b/spec/lib/portal/output_channel_spec.rb
@@ -1,11 +1,11 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Portal::OutputChannel do
   subject(:output_channel) { described_class.new(channel) }
   before do
     stub_request(:post, %r{\Ahttps://slack.com/api/conversations.info\z}).to_return(status: 200, body: expected_body)
   end
-  let(:channel) { 'shared_channel' }
+  let(:channel) { "shared_channel" }
   let(:expected_body) do
     {
       'ok': true,
@@ -15,26 +15,26 @@ RSpec.describe Portal::OutputChannel do
     }.to_json
   end
 
-  describe '#valid?' do
+  describe "#valid?" do
     subject(:valid?) { output_channel.valid? }
 
-    context 'when the channel is the recorded output channel' do
+    context "when the channel is the recorded output channel" do
       it { is_expected.to be true }
     end
 
-    context 'when the channel is not the recorded output channel' do
-      let(:channel) { 'channel' }
+    context "when the channel is not the recorded output channel" do
+      let(:channel) { "channel" }
       it { is_expected.to be false }
     end
   end
 
-  describe '.is' do
+  describe ".is" do
     subject(:is) { described_class.is }
 
-    it { is_expected.to eq ENV['USER_OUTPUT_CHANNEL'] }
+    it { is_expected.to eq ENV["USER_OUTPUT_CHANNEL"] }
   end
 
-  describe '.display_name' do
+  describe ".display_name" do
     subject(:display_name) { described_class.display_name }
 
     it { is_expected.to eq channel }

--- a/spec/lib/portal/user_requestor_spec.rb
+++ b/spec/lib/portal/user_requestor_spec.rb
@@ -1,18 +1,18 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Portal::UserRequester do
-  describe 'initiate' do
-    subject(:user_requester) { described_class.initiate(names, 'channel') }
-    let(:names) { 'test1, test2, test3' }
+  describe "initiate" do
+    subject(:user_requester) { described_class.initiate(names, "channel") }
+    let(:names) { "test1, test2, test3" }
 
-    context 'when all names are matched by portal' do
+    context "when all names are matched by portal" do
       before do
         class_double(Portal::NameValidator, call: true).as_stubbed_const
         instance_double(Portal::Names::Collator, matched_names: %w[TEST1 TEST2 TEST3],
                                                  unmatched_names: [])
       end
 
-      it 'expect the following calls to occur' do
+      it "expect the following calls to occur" do
         expect_any_instance_of(Portal::Messages::Failure).to_not receive(:call)
         expect_any_instance_of(Portal::Messages::Success).to receive(:call).once
         expect_any_instance_of(Portal::GenerateScript).to receive(:call).once
@@ -21,14 +21,14 @@ RSpec.describe Portal::UserRequester do
       end
     end
 
-    context 'when no names are matched by portal' do
+    context "when no names are matched by portal" do
       before do
         class_double(Portal::NameValidator, call: false).as_stubbed_const
         instance_double(Portal::Names::Collator, matched_names: [],
                                                  unmatched_names: %w[TEST1 TEST2 TEST3])
       end
 
-      it 'expect the following calls to occur' do
+      it "expect the following calls to occur" do
         expect_any_instance_of(Portal::Messages::Failure).to receive(:call).once
         expect_any_instance_of(Portal::Messages::Success).to_not receive(:call)
         expect_any_instance_of(Portal::GenerateScript).to_not receive(:call)

--- a/spec/lib/send_slack_message_spec.rb
+++ b/spec/lib/send_slack_message_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe SendSlackMessage do
   subject(:slack) { described_class.new }
@@ -6,65 +6,65 @@ RSpec.describe SendSlackMessage do
 
   it { is_expected.to be_a SendSlackMessage }
 
-  context 'when a slack token is not set' do
-    before { allow(ENV).to receive(:[]).with('SLACK_API_TOKEN').and_return(nil) }
+  context "when a slack token is not set" do
+    before { allow(ENV).to receive(:[]).with("SLACK_API_TOKEN").and_return(nil) }
 
-    it 'raises an error' do
-      expect { slack }.to raise_error('Missing ENV[SLACK_API_TOKEN]!')
+    it "raises an error" do
+      expect { slack }.to raise_error("Missing ENV[SLACK_API_TOKEN]!")
     end
   end
 
-  describe '.generic' do
+  describe ".generic" do
     subject(:generic) { slack.generic(params) }
 
-    let(:params) { { channel: 'test', user: 'test', attachments: [] } }
+    let(:params) { { channel: "test", user: "test", attachments: [] } }
 
-    it 'sends a message to slack' do
+    it "sends a message to slack" do
       subject
-      expect(a_request(:post, 'https://slack.com/api/chat.postMessage')).to have_been_made.times(1)
+      expect(a_request(:post, "https://slack.com/api/chat.postMessage")).to have_been_made.times(1)
     end
   end
 
-  describe '.upload_file' do
+  describe ".upload_file" do
     subject(:upload_file) { slack.upload_file(params) }
 
-    let(:params) { { channels: 'test', content: 'test', filename: 'output.txt' } }
+    let(:params) { { channels: "test", content: "test", filename: "output.txt" } }
 
-    it 'sends a message to slack' do
+    it "sends a message to slack" do
       subject
-      expect(a_request(:post, 'https://slack.com/api/files.upload')).to have_been_made.times(1)
+      expect(a_request(:post, "https://slack.com/api/files.upload")).to have_been_made.times(1)
     end
   end
 
-  describe '.conversations_info' do
+  describe ".conversations_info" do
     subject(:conversations_info) { slack.conversations_info(params) }
 
-    let(:params) { { channel: 'test' } }
+    let(:params) { { channel: "test" } }
 
-    it 'sends a message to slack' do
+    it "sends a message to slack" do
       subject
-      expect(a_request(:post, 'https://slack.com/api/conversations.info')).to have_been_made.times(1)
+      expect(a_request(:post, "https://slack.com/api/conversations.info")).to have_been_made.times(1)
     end
   end
 
-  describe '.update' do
+  describe ".update" do
     subject(:update) { slack.update(params) }
 
-    let(:params) { { ts: '0000.000', channel: 'test', user: 'test', attachments: [] } }
+    let(:params) { { ts: "0000.000", channel: "test", user: "test", attachments: [] } }
 
-    it 'sends an update post to slack' do
+    it "sends an update post to slack" do
       subject
-      expect(a_request(:post, 'https://slack.com/api/chat.update')).to have_been_made.times(1)
+      expect(a_request(:post, "https://slack.com/api/chat.update")).to have_been_made.times(1)
     end
   end
 
-  describe '.user' do
+  describe ".user" do
     subject(:update) { slack.user(params) }
-    let(:params) { { user_id: 'test' } }
+    let(:params) { { user_id: "test" } }
 
-    it 'sends an user POST request to slack' do
+    it "sends an user POST request to slack" do
       subject
-      expect(a_request(:post, 'https://slack.com/api/users.info')).to have_been_made.times(1)
+      expect(a_request(:post, "https://slack.com/api/users.info")).to have_been_made.times(1)
     end
   end
 end

--- a/spec/lib/slack/block_builder_spec.rb
+++ b/spec/lib/slack/block_builder_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Slack::BlockBuilder do
   subject(:block_builder) { described_class.new }
@@ -7,34 +7,34 @@ RSpec.describe Slack::BlockBuilder do
 
   it { is_expected.to be_a Slack::BlockBuilder }
 
-  describe '#call' do
+  describe "#call" do
     subject(:class_call) { described_class.call(state, **args) }
     let(:state) { :start }
 
     it { is_expected.to be_a Hash }
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { block_builder.call(state, **args) }
 
-    context 'when the state is missing' do
+    context "when the state is missing" do
       let(:state) { nil }
 
-      it { expect { call }.to raise_error('State error') }
+      it { expect { call }.to raise_error("State error") }
     end
 
-    context 'when the state is valid' do
+    context "when the state is valid" do
       let(:state) { :start }
       let(:expected_result) do
         {
           blocks:
             [{
-              type: 'section',
-              block_id: 'start',
+              type: "section",
+              block_id: "start",
               text:
                 {
-                  type: 'mrkdwn',
-                  text: ':spinner2: A test run has been requested from Github'
+                  type: "mrkdwn",
+                  text: ":spinner2: A test run has been requested from Github"
                 }
             }]
         }
@@ -44,27 +44,27 @@ RSpec.describe Slack::BlockBuilder do
       it { expect(call).to match(expected_result) }
     end
 
-    context 'when the state is searching' do
+    context "when the state is searching" do
       let(:state) { :searching }
 
       it { expect(call[:blocks].count).to eql 1 }
     end
 
-    context 'when the state is waiting' do
+    context "when the state is waiting" do
       let(:state) { :waiting }
-      let(:args) { { web_url: 'http://github.com/test' } }
+      let(:args) { { web_url: "http://github.com/test" } }
       let(:expected_result) do
         {
           blocks:
           [
             {
-              type: 'section',
-              block_id: 'waiting',
+              type: "section",
+              block_id: "waiting",
               text:
                 {
-                  type: 'mrkdwn',
+                  type: "mrkdwn",
                   text: ":spinner2: The tests are running.\n I'll update you on completion, "\
-                        'or you can click on <http://github.com/test|this link> for details'
+                        "or you can click on <http://github.com/test|this link> for details"
                 }
             }
           ]
@@ -75,26 +75,26 @@ RSpec.describe Slack::BlockBuilder do
       it { expect(call).to match(expected_result) }
     end
 
-    context 'when the state is complete' do
+    context "when the state is complete" do
       let(:state) { :complete }
 
       it { expect(call[:blocks].count).to eql 1 }
     end
   end
 
-  describe '#start_error' do
-    subject(:error_call) { described_class.start_error('this is an error message') }
+  describe "#start_error" do
+    subject(:error_call) { described_class.start_error("this is an error message") }
     let(:expected_result) do
       {
         blocks:
           [
             {
-              type: 'section',
-              block_id: 'error',
+              type: "section",
+              block_id: "error",
               text:
                 {
-                  type: 'mrkdwn',
-                  text: 'Could not trigger job on Github ```this is an error message```'
+                  type: "mrkdwn",
+                  text: "Could not trigger job on Github ```this is an error message```"
                 }
             }
           ]
@@ -105,18 +105,18 @@ RSpec.describe Slack::BlockBuilder do
     it { expect(error_call).to match(expected_result) }
   end
 
-  describe '#timeout_error' do
+  describe "#timeout_error" do
     subject(:error_call) { described_class.timeout_error }
     let(:expected_result) do
       {
         blocks:
           [
             {
-              type: 'section',
-              block_id: 'error',
+              type: "section",
+              block_id: "error",
               text:
                 {
-                  type: 'mrkdwn',
+                  type: "mrkdwn",
                   text: ":nope: It's been over two minutes, you'll need to check github manually"
                 }
             }

--- a/spec/lib/token_generator_spec.rb
+++ b/spec/lib/token_generator_spec.rb
@@ -1,19 +1,19 @@
-require 'rspec'
-require 'lib/token_generator'
+require "rspec"
+require "lib/token_generator"
 
 RSpec.describe TokenGenerator do
   subject(:token_generator) { described_class.new }
 
   it { is_expected.to be_a TokenGenerator }
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { described_class.call(slack_id) }
 
-    let(:slack_id) { 'AB2345' }
+    let(:slack_id) { "AB2345" }
 
     it { is_expected.to be_a String }
 
-    context 'that can be parsed via JSON' do
+    context "that can be parsed via JSON" do
       subject(:decode) { JSON.parse(Base64.urlsafe_decode64(call)) }
 
       it { expect(decode.keys).to match_array %w[expires_at secret slack_id] }

--- a/spec/lib/workers/test_run_locate_spec.rb
+++ b/spec/lib/workers/test_run_locate_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Worker::TestRunLocate do
   subject(:worker) { described_class.new }
@@ -6,8 +6,8 @@ RSpec.describe Worker::TestRunLocate do
 
   it { is_expected.to be_a Worker::TestRunLocate }
 
-  describe '.perform' do
-    subject(:perform) { worker.perform('channel', '000.000', iteration, etag) }
+  describe ".perform" do
+    subject(:perform) { worker.perform("channel", "000.000", iteration, etag) }
 
     before do
       stub_request(:get, %r{\Ahttps://(www|api).github.com/.*/runs.*\z})
@@ -19,9 +19,9 @@ RSpec.describe Worker::TestRunLocate do
     let(:iteration) { 1 }
     let(:etag) { nil }
 
-    context 'when github has an in progress job' do
+    context "when github has an in progress job" do
       before do
-        allow(ENV).to receive(:[]).with('GITHUB_WAIT_SECONDS').and_return(5)
+        allow(ENV).to receive(:[]).with("GITHUB_WAIT_SECONDS").and_return(5)
         stub_request(:get, "#{GithubValues.repo_url}/actions/runs/30433642/jobs")
           .to_return(status: status, body: job_response, headers: {})
       end
@@ -54,123 +54,123 @@ RSpec.describe Worker::TestRunLocate do
       let(:expected_hash) do
         {
           as_user: true,
-          channel: 'channel',
+          channel: "channel",
           blocks: [
             {
-              block_id: 'waiting',
+              block_id: "waiting",
               text:
                 {
                   text: ":spinner2: The tests are running.\n I'll update you on completion, or you can "\
                         "click on <#{web_url}?check_suite_focus=true|this link> for details",
-                  type: 'mrkdwn'
+                  type: "mrkdwn"
                 },
-              type: 'section'
+              type: "section"
             }
           ],
-          ts: '000.000'
+          ts: "000.000"
         }
       end
 
-      it 'sends an update command to slack with a progress message' do
+      it "sends an update command to slack with a progress message" do
         expect_any_instance_of(SendSlackMessage).to receive(:update).with(expected_hash)
         perform
       end
 
-      it 'creates a new MonitorTestRunWorker' do
+      it "creates a new MonitorTestRunWorker" do
         expect { perform }.to change(Worker::TestRunMonitor.jobs, :size).by(1)
       end
     end
 
-    context 'when github does not have any in progress jobs' do
-      before { allow(ENV).to receive(:[]).with('GITHUB_WAIT_SECONDS').and_return(5) }
+    context "when github does not have any in progress jobs" do
+      before { allow(ENV).to receive(:[]).with("GITHUB_WAIT_SECONDS").and_return(5) }
       let(:iteration) { 2 }
 
       let(:expected_hash) do
         {
           as_user: true,
-          channel: 'channel',
+          channel: "channel",
           blocks: [
             {
-              block_id: 'searching',
+              block_id: "searching",
               text:
                 {
-                  text: ':spinner2: A test run has been requested from Github. Time spent looking so far: 10 seconds',
-                  type: 'mrkdwn'
+                  text: ":spinner2: A test run has been requested from Github. Time spent looking so far: 10 seconds",
+                  type: "mrkdwn"
                 },
-              type: 'section'
+              type: "section"
             }
           ],
-          ts: '000.000'
+          ts: "000.000"
         }
       end
 
       let(:response) { { 'total_count': 0 }.to_json }
 
-      it 'sends an update command to slack with a timeout message' do
+      it "sends an update command to slack with a timeout message" do
         expect_any_instance_of(SendSlackMessage).to receive(:update).with(expected_hash)
         perform
       end
 
-      it 'creates a new TestRunLocateWorker' do
+      it "creates a new TestRunLocateWorker" do
         expect { perform }.to change(Worker::TestRunLocate.jobs, :size).by(1)
       end
     end
 
-    context 'when github does not respond as expected' do
-      before { allow(ENV).to receive(:[]).with('GITHUB_WAIT_SECONDS').and_return(5) }
+    context "when github does not respond as expected" do
+      before { allow(ENV).to receive(:[]).with("GITHUB_WAIT_SECONDS").and_return(5) }
       let(:iteration) { 2 }
 
       let(:expected_hash) do
         {
           as_user: true,
-          channel: 'channel',
+          channel: "channel",
           blocks: [
             {
-              block_id: 'searching',
+              block_id: "searching",
               text:
               {
-                text: ':spinner2: A test run has been requested from Github. Time spent looking so far: 10 seconds',
-                type: 'mrkdwn'
+                text: ":spinner2: A test run has been requested from Github. Time spent looking so far: 10 seconds",
+                type: "mrkdwn"
               },
-              type: 'section'
+              type: "section"
             }
           ],
-          ts: '000.000'
+          ts: "000.000"
         }
       end
       let(:status) { 204 }
       let(:response) { { 'unexpected_value': 0 }.to_json }
 
-      it 'sends an update command to slack with a timeout message' do
+      it "sends an update command to slack with a timeout message" do
         expect_any_instance_of(SendSlackMessage).to receive(:update).with(expected_hash)
         perform
       end
     end
 
-    describe 'when the iteration count indicates a timeout' do
-      before { allow(ENV).to receive(:[]).with('GITHUB_WAIT_SECONDS').and_return(61) }
+    describe "when the iteration count indicates a timeout" do
+      before { allow(ENV).to receive(:[]).with("GITHUB_WAIT_SECONDS").and_return(61) }
 
       let(:iteration) { 2 }
       let(:expected_hash) do
         {
           as_user: true,
-          channel: 'channel',
+          channel: "channel",
           blocks: [
             {
-              block_id: 'error',
+              block_id: "error",
               text:
                 {
                   text: ":nope: It's been over two minutes, you'll need to check github manually",
-                  type: 'mrkdwn'
+                  type: "mrkdwn"
                 },
-              type: 'section'
+              type: "section"
             }
           ],
-          ts: '000.000'
+          ts: "000.000"
         }
       end
 
-      it 'sends an update command to slack with a timeout message' do
+      it "sends an update command to slack with a timeout message" do
         expect_any_instance_of(SendSlackMessage).to receive(:update).with(expected_hash)
         perform
       end

--- a/spec/lib/workers/test_run_monitor_spec.rb
+++ b/spec/lib/workers/test_run_monitor_spec.rb
@@ -1,34 +1,34 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Worker::TestRunMonitor do
   subject(:worker) { described_class.new }
 
   it { is_expected.to be_a Worker::TestRunMonitor }
 
-  describe '.perform' do
+  describe ".perform" do
     subject(:perform) { worker.perform(monitor_url, delay, data, web_url, timestamp) }
     before do
       stub_request(:any, %r{\Ahttps://(www|api).github.com/.*\z})
         .to_return(status: 200, body: response, headers: {})
     end
 
-    let(:monitor_url) { 'https://api.github.com/repos/moj/project/job/123' }
+    let(:monitor_url) { "https://api.github.com/repos/moj/project/job/123" }
     let(:delay) { 45 }
-    let(:data) { { 'channel' => 'test', 'user' => 'test' } }
-    let(:web_url) { 'https://www.github.com/repos/moj/project/job/123' }
-    let(:timestamp) { '1595341466.004300' }
-    let(:response) { { 'status': 'in_progress' }.to_json }
+    let(:data) { { "channel" => "test", "user" => "test" } }
+    let(:web_url) { "https://www.github.com/repos/moj/project/job/123" }
+    let(:timestamp) { "1595341466.004300" }
+    let(:response) { { 'status': "in_progress" }.to_json }
 
-    context 'when the job has not completed' do
-      it 'creates a new MonitorTestRunWorker' do
+    context "when the job has not completed" do
+      it "creates a new MonitorTestRunWorker" do
         expect { perform }.to change(Worker::TestRunMonitor.jobs, :size).by(1)
       end
     end
 
-    context 'when the job has completed' do
-      let(:response) { { 'status': 'completed' }.to_json }
+    context "when the job has completed" do
+      let(:response) { { 'status': "completed" }.to_json }
 
-      it 'updates the slack message' do
+      it "updates the slack message" do
         expect_any_instance_of(SendSlackMessage).to receive(:update).once
         perform
       end

--- a/spec/lib/workers/test_run_start_spec.rb
+++ b/spec/lib/workers/test_run_start_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 RSpec.describe Worker::TestRunStart do
   subject(:worker) { described_class.new }
@@ -7,59 +7,59 @@ RSpec.describe Worker::TestRunStart do
     stub_user = Struct.new(:id, :real_name)
     stub_request(:post, %r{\Ahttps://(www|api).github.com/.*/dispatches\z}).to_return(response)
     allow_any_instance_of(SendSlackMessage).to receive(:user)
-      .and_return(stub_user.new({ id: 'AB123CDEF', real_name: 'test user' }))
-    allow_any_instance_of(SendSlackMessage).to receive(:generic).and_return({ ts: '1595341466.004300' })
+      .and_return(stub_user.new({ id: "AB123CDEF", real_name: "test user" }))
+    allow_any_instance_of(SendSlackMessage).to receive(:generic).and_return({ ts: "1595341466.004300" })
   end
 
-  let(:slack_user_response) { { status: 200, body: { id: 'UQ785LQGH', real_name: 'test user' }.to_json, headers: {} } }
+  let(:slack_user_response) { { status: 200, body: { id: "UQ785LQGH", real_name: "test user" }.to_json, headers: {} } }
   let(:response) { good_response }
-  let(:good_response) { { status: 204, body: '', headers: {} } }
-  let(:bad_response) { { status: 422, body: '', headers: {} } }
+  let(:good_response) { { status: 204, body: "", headers: {} } }
+  let(:bad_response) { { status: 422, body: "", headers: {} } }
 
   it { is_expected.to be_a Worker::TestRunStart }
 
-  describe '.perform' do
+  describe ".perform" do
     subject(:perform) { worker.perform(data) }
 
-    let(:data) { { 'channel' => 'test', 'user' => 'test' } }
+    let(:data) { { "channel" => "test", "user" => "test" } }
 
-    context 'when the job is successfully started in github and located' do
-      it 'polls github for data' do
+    context "when the job is successfully started in github and located" do
+      it "polls github for data" do
         perform
-        expect(a_request(:post, 'https://api.github.com/repos/moj/project/dispatches')).to have_been_made.times(1)
+        expect(a_request(:post, "https://api.github.com/repos/moj/project/dispatches")).to have_been_made.times(1)
       end
 
-      it 'sends a slack message' do
+      it "sends a slack message" do
         expect_any_instance_of(SendSlackMessage).to receive(:generic)
         perform
       end
 
-      it 'creates a new MonitorTestRunWorker' do
+      it "creates a new MonitorTestRunWorker" do
         expect { perform }.to change(Worker::TestRunLocate.jobs, :size).by(1)
       end
     end
 
-    context 'when the job cannot be started in github' do
+    context "when the job cannot be started in github" do
       let(:response) { bad_response }
       let(:expected_hash) do
         {
           as_user: true,
-          channel: 'test',
+          channel: "test",
           blocks: [
             {
-              block_id: 'error',
+              block_id: "error",
               text:
                 {
-                  text: 'Could not trigger job on Github ```422 Unprocessable Entity```',
-                  type: 'mrkdwn'
+                  text: "Could not trigger job on Github ```422 Unprocessable Entity```",
+                  type: "mrkdwn"
                 },
-              type: 'section'
+              type: "section"
             }
           ]
         }
       end
 
-      it 'polls github for data' do
+      it "polls github for data" do
         expect_any_instance_of(SendSlackMessage).to receive(:generic).with(expected_hash)
         perform
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,35 +1,35 @@
-require 'rspec'
-require 'models/user'
+require "rspec"
+require "models/user"
 
 describe User, type: :model do
-  subject(:user) { described_class.find_or_create_by!(slack_id: 'fake_id') }
+  subject(:user) { described_class.find_or_create_by!(slack_id: "fake_id") }
   it { is_expected.to validate_presence_of(:slack_id) }
   it { is_expected.to validate_uniqueness_of(:slack_id) }
 
-  describe '#otp_secret=' do
-    before { user.otp_secret = 'secret' }
-    it 'records an encrypted string' do
-      expect(user.reload.encrypted_2fa_secret).to_not eql 'secret'
+  describe "#otp_secret=" do
+    before { user.otp_secret = "secret" }
+    it "records an encrypted string" do
+      expect(user.reload.encrypted_2fa_secret).to_not eql "secret"
     end
 
-    it 'sets enabled_2fa to true' do
+    it "sets enabled_2fa to true" do
       expect(user.reload.enabled_2fa).to be true
     end
   end
 
-  describe '#otp_secret_valid?' do
+  describe "#otp_secret_valid?" do
     before do
-      user.otp_secret = 'secret'
+      user.otp_secret = "secret"
       user.otp_secret_valid?(value)
     end
 
-    context 'when the passed value matches the decrypted version' do
-      let(:value) { 'secret' }
+    context "when the passed value matches the decrypted version" do
+      let(:value) { "secret" }
       it { expect(user.reload.otp_secret_valid?(value)).to be true }
     end
 
-    context 'when the encrypted value is different' do
-      let(:value) { 'public' }
+    context "when the encrypted value is different" do
+      let(:value) { "public" }
       it { expect(user.reload.otp_secret_valid?(value)).to be false }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,48 +1,48 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
-require 'simplecov'
-require 'highline/import'
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), ".."))
+require "simplecov"
+require "highline/import"
 SimpleCov.minimum_coverage 100
-unless ENV['NOCOVERAGE']
+unless ENV["NOCOVERAGE"]
   SimpleCov.start do
-    add_filter 'spec/'
-    add_filter 'config/'
-    add_group 'Libraries', 'lib/'
+    add_filter "spec/"
+    add_filter "config/"
+    add_group "Libraries", "lib/"
   end
   SimpleCov.at_exit do
     say("<%= color('Code coverage below 100%', RED) %>") if SimpleCov.result.coverage_statistics[:line].percent < 100
     SimpleCov.result.format!
   end
 end
-ENV['RACK_ENV'] = 'test'
-ENV['ENV'] = 'test'
+ENV["RACK_ENV"] = "test"
+ENV["ENV"] = "test"
 
-require 'timecop'
-require 'sidekiq'
-require 'sidekiq/testing'
+require "timecop"
+require "sidekiq"
+require "sidekiq/testing"
 Sidekiq::Testing.fake!
-require 'webmock'
-require 'webmock/rspec'
+require "webmock"
+require "webmock/rspec"
 WebMock.disable_net_connect!
-require 'pry'
-require 'slack-ruby-bot/rspec'
-require 'vcr_helper'
-require 'app'
-require 'shoulda/matchers'
-require 'database_cleaner'
-require 'dotenv'
-Dotenv.load('.env.test')
+require "pry"
+require "slack-ruby-bot/rspec"
+require "vcr_helper"
+require "app"
+require "shoulda/matchers"
+require "database_cleaner"
+require "dotenv"
+Dotenv.load(".env.test")
 
-Dir[File.join('slack-applybot/**/*.rb'), File.join('lib/**/*.rb')].sort.each do |f|
+Dir[File.join("slack-applybot/**/*.rb"), File.join("lib/**/*.rb")].sort.each do |f|
   file = File.join(File.dirname(f), File.basename(f, File.extname(f)))
   require file
 end
 
-Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.before do
-    stub_request(:post, %r{\Ahttps://slack.com/api/.*\z}).to_return(status: 200, body: '', headers: {})
-    stub_request(:any, %r{\Ahttps://(www|api).github.com/.*\z}).to_return(status: 200, body: '', headers: {})
+    stub_request(:post, %r{\Ahttps://slack.com/api/.*\z}).to_return(status: 200, body: "", headers: {})
+    stub_request(:any, %r{\Ahttps://(www|api).github.com/.*\z}).to_return(status: 200, body: "", headers: {})
   end
   config.include(Shoulda::Matchers::ActiveModel, type: :model)
   config.include(Shoulda::Matchers::ActiveRecord, type: :model)

--- a/spec/support/commit.rb
+++ b/spec/support/commit.rb
@@ -2,14 +2,14 @@
 def load_shared_commit_data
   let(:commits) do
     [
-      { 'sha': '123456', 'url': '123456', 'commit': { 'message': "Merge pull request #1999 from moj/AA-1234\n\nImprove something important" } },
-      { 'sha': '234567', 'url': '234567', 'commit': { 'message': "Merge pull request #1998 from moj/AA-421\n\nMinor tweak to something" } },
-      { 'sha': '345678', 'url': '345678', 'commit': { 'message': "Improve the thing\n\nSo that the other thing looks better" } },
-      { 'sha': '456789', 'url': '456789', 'commit': { 'message': "Tweak the layout of results\n\nShould have been left aligned" } },
-      { 'sha': '678912', 'url': '678912', 'commit': { 'message': "Merge pull request #1997 from moj/AA-666\n\nMade everything shiny" } },
-      { 'sha': '789123', 'url': '789123', 'commit': { 'message': "Merge pull request #1996 from moj/AA-555\n\nMade everything dull" } },
-      { 'sha': '891234', 'url': '891234', 'commit': { 'message': "Merge pull request #1995 from moj/AA-444\n\nMade everything work" } },
-      { 'sha': '912345', 'url': '912345', 'commit': { 'message': "Merge pull request #1994 from moj/AA-333\n\nMade some stuff work" } }
+      { 'sha': "123456", 'url': "123456", 'commit': { 'message': "Merge pull request #1999 from moj/AA-1234\n\nImprove something important" } },
+      { 'sha': "234567", 'url': "234567", 'commit': { 'message': "Merge pull request #1998 from moj/AA-421\n\nMinor tweak to something" } },
+      { 'sha': "345678", 'url': "345678", 'commit': { 'message': "Improve the thing\n\nSo that the other thing looks better" } },
+      { 'sha': "456789", 'url': "456789", 'commit': { 'message': "Tweak the layout of results\n\nShould have been left aligned" } },
+      { 'sha': "678912", 'url': "678912", 'commit': { 'message': "Merge pull request #1997 from moj/AA-666\n\nMade everything shiny" } },
+      { 'sha': "789123", 'url': "789123", 'commit': { 'message': "Merge pull request #1996 from moj/AA-555\n\nMade everything dull" } },
+      { 'sha': "891234", 'url': "891234", 'commit': { 'message': "Merge pull request #1995 from moj/AA-444\n\nMade everything work" } },
+      { 'sha': "912345", 'url': "912345", 'commit': { 'message': "Merge pull request #1994 from moj/AA-333\n\nMade some stuff work" } }
     ].to_json
   end
 end

--- a/spec/support/shared_examples/invalid_channel.rb
+++ b/spec/support/shared_examples/invalid_channel.rb
@@ -1,14 +1,14 @@
-RSpec.shared_examples 'the channel is invalid' do
+RSpec.shared_examples "the channel is invalid" do
   let!(:client) { SlackRubyBot::App.new.send(:client) }
   let(:message_hook) { SlackRubyBot::Hooks::Message.new }
-  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: 'user') }
-  let(:channel) { 'dangerous' }
+  let(:params) { Hashie::Mash.new(text: user_input, channel: channel, user: "user") }
+  let(:channel) { "dangerous" }
   let(:expected_response) { "Sorry <@user>, I don't understand that command!" }
   let(:expected_hash) do
     { channel: channel, as_user: true, text: "Sorry <@user>, I don't understand that command!" }
   end
 
-  it 'raises a message-sending error' do
+  it "raises a message-sending error" do
     expect_any_instance_of(SendSlackMessage).to receive(:generic).with(expected_hash)
     expect { message_hook.call(client, params) }.to raise_error ChannelValidity::PublicError
   end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -1,11 +1,11 @@
-require 'vcr'
+require "vcr"
 
 VCR.configure do |c|
-  c.cassette_library_dir = 'vcr/cassettes'
+  c.cassette_library_dir = "vcr/cassettes"
   c.hook_into :webmock
   c.configure_rspec_metadata!
-  c.debug_logger = $stderr if ENV['VCR_DEBUG']
+  c.debug_logger = $stderr if ENV["VCR_DEBUG"]
 
-  c.filter_sensitive_data('<GITHUB_ORG>') { ENV['GITHUB_ORG'] }
-  c.filter_sensitive_data('<GITHUB_REPO>') { ENV['GITHUB_REPO'] }
+  c.filter_sensitive_data("<GITHUB_ORG>") { ENV["GITHUB_ORG"] }
+  c.filter_sensitive_data("<GITHUB_REPO>") { ENV["GITHUB_REPO"] }
 end


### PR DESCRIPTION
Remove the override in `.rubocop_todo` and run `rubocop -A`
