### PR TITLE
Rubocop: Address Performance/* cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,18 +19,6 @@ Lint/RedundantCopDisableDirective:
   Exclude:
     - 'spec/support/commit.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RedundantMatch:
-  Exclude:
-    - 'slack-applybot/commands/_two_factor_auth_shared.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RegexpMatch:
-  Exclude:
-    - 'slack-applybot/commands/_two_factor_auth_shared.rb'
-
 # Offense count: 28
 RSpec/AnyInstance:
   Exclude:

--- a/slack-applybot/commands/_two_factor_auth_shared.rb
+++ b/slack-applybot/commands/_two_factor_auth_shared.rb
@@ -4,7 +4,7 @@ module TwoFactorAuthShared
   private
 
   def validate_otp_part(otp)
-    validate(user, otp) if otp.match(/\d*/)
+    validate(user, otp) if /\d*/.match?(otp)
   end
 
   def validate(user, otp)


### PR DESCRIPTION
Remove the override in `.rubocop_todo` and run `rubocop -A`