### PR TITLE
Update Helm delete handling

### DIFF
--- a/lib/helm/delete.rb
+++ b/lib/helm/delete.rb
@@ -1,6 +1,7 @@
 module Helm
   class Delete
-    def self.call(release)
+    def self.call(context = "apply", release)
+      @context = "--kube-context #{context}-context"
       @release = release
       remove_release if dry_run?
     end
@@ -9,12 +10,12 @@ module Helm
     private
 
       def remove_release
-        result = `helm delete #{@release}`.chomp
+        result = `helm delete #{@context} #{@release}`.chomp
         result.eql?("release \"#{@release}\" uninstalled")
       end
 
       def dry_run?
-        result = `helm delete #{@release} --dry-run`.chomp
+        result = `helm delete #{@context} #{@release} --dry-run`.chomp
         result.eql?("release \"#{@release}\" uninstalled")
       end
     end

--- a/slack-applybot/commands/helm.rb
+++ b/slack-applybot/commands/helm.rb
@@ -28,12 +28,14 @@ module SlackApplybot
 
         def process_delete(match)
           parts = match["expression"].split - %w[delete]
+          context = (VALID_CONTEXTS & parts).first || "apply"
+          parts -= [context]
           if parts.empty?
             "Unable to delete - insufficient data, please call as `helm delete name-of-release 000000`"
           elsif parts.count.eql?(1)
             "OTP password not provided, please call as `helm delete name-of-release 000000`"
           elsif validate_otp_part(parts[1])
-            ::Helm::Delete.call(parts[0]) ? "#{parts[0]} deleted" : "Unable to delete"
+            ::Helm::Delete.call(context, parts[0]) ? "#{parts[0]} deleted" : "Unable to delete"
           else
             "OTP password did not match, please check your authenticator app"
           end


### PR DESCRIPTION
This allows deletion of helm instances on namespaces other than
apply, e.g. cfe, lfa, etc