### PR TITLE
Update Async

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 ruby "3.1.2"
 
 gem "activerecord", "> 6.1.4", "< 8"
-gem "async", "~> 1.30.2"
+gem "async"
 gem "async-websocket"
 gem "dotenv"
 gem "dotiw"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,9 +28,9 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
     ast (2.4.2)
-    async (1.30.2)
+    async (2.0.2)
       console (~> 1.10)
-      nio4r (~> 2.3)
+      io-event (~> 1.0.0)
       timers (~> 4.1)
     async-io (1.33.0)
       async
@@ -121,6 +121,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    io-event (1.0.9)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -344,7 +345,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (> 6.1.4, < 8)
-  async (~> 1.30.2)
+  async
   async-websocket
   byebug
   database_cleaner


### PR DESCRIPTION
The first update to Async 2+ broke when deployed to live use so it was locked at 1.3.x

Having built a working local docker image this issue seems to have been resolved so this removes the 1.3.x lock and updates the gem to 2.0.2

It will be deployed to production and checked